### PR TITLE
fix bug NPE on ApiException.getMessage()

### DIFF
--- a/src/main/java/com/onesignal/client/ApiClient.java
+++ b/src/main/java/com/onesignal/client/ApiClient.java
@@ -1035,7 +1035,7 @@ public class ApiClient {
                     callback.onFailure(e, response.code(), response.headers().toMultimap());
                     return;
                 } catch (Exception e) {
-                    callback.onFailure(new ApiException(e), response.code(), response.headers().toMultimap());
+                    callback.onFailure(new ApiException(e.getMessage(), e, response.code(), response.headers().toMultimap(), response.message()), response.code(), response.headers().toMultimap());
                     return;
                 }
                 callback.onSuccess(result, response.code(), response.headers().toMultimap());


### PR DESCRIPTION
# Description
## One Line Summary
As explained in the issue being solved, when an ApiException is thrown and exception.printStackTrace() or just exception.getMessage() is called, then a NullPointerException is thrown due to the getMessage() function implementation

## Details

### Motivation
The change is made for a bug report, with the goal of fixing the problem present in the ApiException.getMessage()

# Testing

## Manual testing
The test that was run is the one in the open issue.
Upon attempting to send a notification the result of which will go to 'onFailure', upon printing the exception message or stack trace a null pointer will be thrown.


# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.