### PR TITLE
fix: openapi definition should define usage of app_key

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -970,6 +970,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/RateLimiterError'
           description: Rate Limit Exceeded
+      security:
+        - app_key: [ ]
       x-accepts: application/json
     get:
       description: "Returns the User’s properties, Aliases, and Subscriptions."


### PR DESCRIPTION
# Description
## One Line Summary
Add usage of app_key also in the deleteUser function, otherwise deleteUser will always result in 403 error.

## Details

### Motivation
Fixing bug #35 opened by me, causing users could not be deleted, causing no compliance with GDPR

### Scope
Being GDPR compliant when using OneSignal from Java.

# Testing

## Manual testing
Simply created a user and deleted it again, on success the patch works.

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.