### PR TITLE
docs: update auth key references to match public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 OneSignal
 - API version: 1.4.0
-  - Build date: 2025-02-20T21:54:45.185Z[Etc/UTC]
+  - Build date: 2025-04-25T19:31:57.613Z[Etc/UTC]
 
 A powerful way to send personalized messages at scale and build effective customer engagement strategies. Learn more at onesignal.com
 
@@ -90,8 +90,8 @@ import com.onesignal.client.api.DefaultApi;
 
 public class Example {
   private static final String appId = "YOUR_APP_ID";
-  private static final String appKeyToken = "YOUR_APP_KEY";
-  private static final String userKeyToken = "YOUR_USER_TOKEN";
+  private static final String restKeyToken = "YOUR_REST_API_KEY"; // App REST API key required for most endpoints
+  private static final String orgKeyToken = "YOUR_ORGANIZATION_API_KEY"; // Organization key is only required for creating new apps and other top-level endpoints
 
   private static Notification createNotification() {
     Notification notification = new Notification();
@@ -110,9 +110,9 @@ public class Example {
     // Setting up the client
     ApiClient defaultClient = Configuration.getDefaultApiClient();
     HttpBearerAuth appKey = (HttpBearerAuth) defaultClient.getAuthentication("app_key");
-    appKey.setBearerToken(appKeyToken);
+    appKey.setBearerToken(restKeyToken);
     HttpBearerAuth userKey = (HttpBearerAuth) defaultClient.getAuthentication("user_key");
-    userKey.setBearerToken(userKeyToken);
+    userKey.setBearerToken(orgKeyToken);
     api = new DefaultApi(defaultClient);
 
     // Setting up the notification

--- a/src/main/java/com/onesignal/client/ApiException.java
+++ b/src/main/java/com/onesignal/client/ApiException.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.GenericType;
  * <p>ApiException class.</p>
  */
 @SuppressWarnings("serial")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/com/onesignal/client/Configuration.java
+++ b/src/main/java/com/onesignal/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package com.onesignal.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/com/onesignal/client/Pair.java
+++ b/src/main/java/com/onesignal/client/Pair.java
@@ -13,7 +13,7 @@
 
 package com.onesignal.client;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/com/onesignal/client/StringUtil.java
+++ b/src/main/java/com/onesignal/client/StringUtil.java
@@ -16,7 +16,7 @@ package com.onesignal.client;
 import java.util.Collection;
 import java.util.Iterator;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/com/onesignal/client/auth/ApiKeyAuth.java
+++ b/src/main/java/com/onesignal/client/auth/ApiKeyAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/com/onesignal/client/auth/HttpBearerAuth.java
+++ b/src/main/java/com/onesignal/client/auth/HttpBearerAuth.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class HttpBearerAuth implements Authentication {
   private final String scheme;
   private String bearerToken;

--- a/src/main/java/com/onesignal/client/model/AbstractOpenApiSchema.java
+++ b/src/main/java/com/onesignal/client/model/AbstractOpenApiSchema.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.GenericType;
 /**
  * Abstract class for oneOf,anyOf schemas defined in OpenAPI spec
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public abstract class AbstractOpenApiSchema {
 
     // store the actual instance of the schema/object

--- a/src/main/java/com/onesignal/client/model/App.java
+++ b/src/main/java/com/onesignal/client/model/App.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * App
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class App {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/BasicNotification.java
+++ b/src/main/java/com/onesignal/client/model/BasicNotification.java
@@ -58,7 +58,7 @@ import com.onesignal.client.JSON;
 /**
  * BasicNotification
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class BasicNotification {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/BasicNotificationAllOf.java
+++ b/src/main/java/com/onesignal/client/model/BasicNotificationAllOf.java
@@ -55,7 +55,7 @@ import com.onesignal.client.JSON;
 /**
  * BasicNotificationAllOf
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class BasicNotificationAllOf {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/BasicNotificationAllOfAndroidBackgroundLayout.java
+++ b/src/main/java/com/onesignal/client/model/BasicNotificationAllOfAndroidBackgroundLayout.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
  * Channel: Push Notifications Platform: Android Allowing setting a background image for the notification. This is a JSON object containing the following keys. See our Background Image documentation for image sizes. 
  */
 @ApiModel(description = "Channel: Push Notifications Platform: Android Allowing setting a background image for the notification. This is a JSON object containing the following keys. See our Background Image documentation for image sizes. ")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class BasicNotificationAllOfAndroidBackgroundLayout {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/BeginLiveActivityRequest.java
+++ b/src/main/java/com/onesignal/client/model/BeginLiveActivityRequest.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * BeginLiveActivityRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class BeginLiveActivityRequest {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Button.java
+++ b/src/main/java/com/onesignal/client/model/Button.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * Button
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Button {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CancelNotificationSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/CancelNotificationSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * CancelNotificationSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CancelNotificationSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateNotificationSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreateNotificationSuccessResponse.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateNotificationSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateNotificationSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreatePlayerSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreatePlayerSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * CreatePlayerSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreatePlayerSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateSegmentConflictResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreateSegmentConflictResponse.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateSegmentConflictResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateSegmentConflictResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateSegmentSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreateSegmentSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateSegmentSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateSegmentSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateSubscriptionRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/CreateSubscriptionRequestBody.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateSubscriptionRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateSubscriptionRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateUserConflictResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreateUserConflictResponse.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateUserConflictResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateUserConflictResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateUserConflictResponseErrorsInner.java
+++ b/src/main/java/com/onesignal/client/model/CreateUserConflictResponseErrorsInner.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateUserConflictResponseErrorsInner
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateUserConflictResponseErrorsInner {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/CreateUserConflictResponseErrorsItemsMeta.java
+++ b/src/main/java/com/onesignal/client/model/CreateUserConflictResponseErrorsItemsMeta.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * CreateUserConflictResponseErrorsItemsMeta
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class CreateUserConflictResponseErrorsItemsMeta {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/DeletePlayerNotFoundResponse.java
+++ b/src/main/java/com/onesignal/client/model/DeletePlayerNotFoundResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * DeletePlayerNotFoundResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class DeletePlayerNotFoundResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/DeletePlayerSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/DeletePlayerSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * DeletePlayerSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class DeletePlayerSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/DeleteSegmentNotFoundResponse.java
+++ b/src/main/java/com/onesignal/client/model/DeleteSegmentNotFoundResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * DeleteSegmentNotFoundResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class DeleteSegmentNotFoundResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/DeleteSegmentSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/DeleteSegmentSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * DeleteSegmentSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class DeleteSegmentSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/DeliveryData.java
+++ b/src/main/java/com/onesignal/client/model/DeliveryData.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * DeliveryData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class DeliveryData {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/ExportEventsSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/ExportEventsSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * ExportEventsSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class ExportEventsSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/ExportPlayersRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/ExportPlayersRequestBody.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * ExportPlayersRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class ExportPlayersRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/ExportPlayersSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/ExportPlayersSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * ExportPlayersSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class ExportPlayersSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Filter.java
+++ b/src/main/java/com/onesignal/client/model/Filter.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * Filter
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Filter {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/FilterExpressions.java
+++ b/src/main/java/com/onesignal/client/model/FilterExpressions.java
@@ -60,7 +60,7 @@ import com.google.gson.JsonParseException;
 
 import com.onesignal.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class FilterExpressions extends AbstractOpenApiSchema {
     private static final Logger log = Logger.getLogger(FilterExpressions.class.getName());
 

--- a/src/main/java/com/onesignal/client/model/GenericError.java
+++ b/src/main/java/com/onesignal/client/model/GenericError.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * GenericError
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class GenericError {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/GenericErrorErrorsInner.java
+++ b/src/main/java/com/onesignal/client/model/GenericErrorErrorsInner.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * GenericErrorErrorsInner
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class GenericErrorErrorsInner {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/GetNotificationRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/GetNotificationRequestBody.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * GetNotificationRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class GetNotificationRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/InlineResponse200.java
+++ b/src/main/java/com/onesignal/client/model/InlineResponse200.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * InlineResponse200
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class InlineResponse200 {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/InlineResponse2003.java
+++ b/src/main/java/com/onesignal/client/model/InlineResponse2003.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * InlineResponse2003
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class InlineResponse2003 {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/InlineResponse201.java
+++ b/src/main/java/com/onesignal/client/model/InlineResponse201.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * InlineResponse201
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class InlineResponse201 {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/InlineResponse202.java
+++ b/src/main/java/com/onesignal/client/model/InlineResponse202.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * InlineResponse202
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class InlineResponse202 {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/InvalidIdentifierError.java
+++ b/src/main/java/com/onesignal/client/model/InvalidIdentifierError.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * InvalidIdentifierError
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class InvalidIdentifierError {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Notification.java
+++ b/src/main/java/com/onesignal/client/model/Notification.java
@@ -59,7 +59,7 @@ import com.onesignal.client.JSON;
 /**
  * Notification
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Notification {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Notification200Errors.java
+++ b/src/main/java/com/onesignal/client/model/Notification200Errors.java
@@ -61,7 +61,7 @@ import com.google.gson.JsonParseException;
 
 import com.onesignal.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Notification200Errors extends AbstractOpenApiSchema {
     private static final Logger log = Logger.getLogger(Notification200Errors.class.getName());
     public static interface ListString extends List<String> {}

--- a/src/main/java/com/onesignal/client/model/NotificationAllOf.java
+++ b/src/main/java/com/onesignal/client/model/NotificationAllOf.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * NotificationAllOf
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class NotificationAllOf {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/NotificationHistorySuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/NotificationHistorySuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * NotificationHistorySuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class NotificationHistorySuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/NotificationSlice.java
+++ b/src/main/java/com/onesignal/client/model/NotificationSlice.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * NotificationSlice
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class NotificationSlice {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/NotificationTarget.java
+++ b/src/main/java/com/onesignal/client/model/NotificationTarget.java
@@ -64,7 +64,7 @@ import com.google.gson.JsonParseException;
 
 import com.onesignal.client.JSON;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class NotificationTarget extends AbstractOpenApiSchema {
     private static final Logger log = Logger.getLogger(NotificationTarget.class.getName());
 

--- a/src/main/java/com/onesignal/client/model/NotificationWithMeta.java
+++ b/src/main/java/com/onesignal/client/model/NotificationWithMeta.java
@@ -62,7 +62,7 @@ import com.onesignal.client.JSON;
 /**
  * NotificationWithMeta
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class NotificationWithMeta {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/NotificationWithMetaAllOf.java
+++ b/src/main/java/com/onesignal/client/model/NotificationWithMetaAllOf.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * NotificationWithMetaAllOf
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class NotificationWithMetaAllOf {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Operator.java
+++ b/src/main/java/com/onesignal/client/model/Operator.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * Operator
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Operator {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/OutcomeData.java
+++ b/src/main/java/com/onesignal/client/model/OutcomeData.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * OutcomeData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class OutcomeData {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/OutcomesData.java
+++ b/src/main/java/com/onesignal/client/model/OutcomesData.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * OutcomesData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class OutcomesData {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PlatformDeliveryData.java
+++ b/src/main/java/com/onesignal/client/model/PlatformDeliveryData.java
@@ -53,7 +53,7 @@ import com.onesignal.client.JSON;
  * Hash of delivery statistics broken out by target device platform.
  */
 @ApiModel(description = "Hash of delivery statistics broken out by target device platform.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PlatformDeliveryData {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PlatformDeliveryDataEmailAllOf.java
+++ b/src/main/java/com/onesignal/client/model/PlatformDeliveryDataEmailAllOf.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * PlatformDeliveryDataEmailAllOf
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PlatformDeliveryDataEmailAllOf {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PlatformDeliveryDataSmsAllOf.java
+++ b/src/main/java/com/onesignal/client/model/PlatformDeliveryDataSmsAllOf.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * PlatformDeliveryDataSmsAllOf
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PlatformDeliveryDataSmsAllOf {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Player.java
+++ b/src/main/java/com/onesignal/client/model/Player.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * Player
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Player {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PlayerNotificationTarget.java
+++ b/src/main/java/com/onesignal/client/model/PlayerNotificationTarget.java
@@ -52,7 +52,7 @@ import com.onesignal.client.JSON;
 /**
  * PlayerNotificationTarget
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PlayerNotificationTarget {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PlayerNotificationTargetIncludeAliases.java
+++ b/src/main/java/com/onesignal/client/model/PlayerNotificationTargetIncludeAliases.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * PlayerNotificationTargetIncludeAliases
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PlayerNotificationTargetIncludeAliases {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PlayerSlice.java
+++ b/src/main/java/com/onesignal/client/model/PlayerSlice.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * PlayerSlice
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PlayerSlice {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PropertiesDeltas.java
+++ b/src/main/java/com/onesignal/client/model/PropertiesDeltas.java
@@ -52,7 +52,7 @@ import com.onesignal.client.JSON;
 /**
  * PropertiesDeltas
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PropertiesDeltas {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/PropertiesObject.java
+++ b/src/main/java/com/onesignal/client/model/PropertiesObject.java
@@ -54,7 +54,7 @@ import com.onesignal.client.JSON;
 /**
  * PropertiesObject
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class PropertiesObject {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Purchase.java
+++ b/src/main/java/com/onesignal/client/model/Purchase.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * Purchase
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Purchase {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/RateLimiterError.java
+++ b/src/main/java/com/onesignal/client/model/RateLimiterError.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * RateLimiterError
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class RateLimiterError {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/Segment.java
+++ b/src/main/java/com/onesignal/client/model/Segment.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * Segment
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class Segment {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/SegmentNotificationTarget.java
+++ b/src/main/java/com/onesignal/client/model/SegmentNotificationTarget.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * SegmentNotificationTarget
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class SegmentNotificationTarget {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/StringMap.java
+++ b/src/main/java/com/onesignal/client/model/StringMap.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * StringMap
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class StringMap {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/SubscriptionObject.java
+++ b/src/main/java/com/onesignal/client/model/SubscriptionObject.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * SubscriptionObject
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class SubscriptionObject {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/TransferSubscriptionRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/TransferSubscriptionRequestBody.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * TransferSubscriptionRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class TransferSubscriptionRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdateLiveActivityRequest.java
+++ b/src/main/java/com/onesignal/client/model/UpdateLiveActivityRequest.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdateLiveActivityRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdateLiveActivityRequest {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdateLiveActivitySuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/UpdateLiveActivitySuccessResponse.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdateLiveActivitySuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdateLiveActivitySuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdatePlayerSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/UpdatePlayerSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdatePlayerSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdatePlayerSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdatePlayerTagsRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/UpdatePlayerTagsRequestBody.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdatePlayerTagsRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdatePlayerTagsRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdatePlayerTagsSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/UpdatePlayerTagsSuccessResponse.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdatePlayerTagsSuccessResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdatePlayerTagsSuccessResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdateSubscriptionRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/UpdateSubscriptionRequestBody.java
@@ -49,7 +49,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdateSubscriptionRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdateSubscriptionRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UpdateUserRequest.java
+++ b/src/main/java/com/onesignal/client/model/UpdateUserRequest.java
@@ -50,7 +50,7 @@ import com.onesignal.client.JSON;
 /**
  * UpdateUserRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UpdateUserRequest {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/User.java
+++ b/src/main/java/com/onesignal/client/model/User.java
@@ -55,7 +55,7 @@ import com.onesignal.client.JSON;
 /**
  * User
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class User {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UserIdentityRequestBody.java
+++ b/src/main/java/com/onesignal/client/model/UserIdentityRequestBody.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * UserIdentityRequestBody
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UserIdentityRequestBody {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UserIdentityResponse.java
+++ b/src/main/java/com/onesignal/client/model/UserIdentityResponse.java
@@ -51,7 +51,7 @@ import com.onesignal.client.JSON;
 /**
  * UserIdentityResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UserIdentityResponse {
   private static final long serialVersionUID = 1L;
 

--- a/src/main/java/com/onesignal/client/model/UserSubscriptionOptions.java
+++ b/src/main/java/com/onesignal/client/model/UserSubscriptionOptions.java
@@ -48,7 +48,7 @@ import com.onesignal.client.JSON;
 /**
  * UserSubscriptionOptions
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-02-20T21:54:45.185Z[Etc/UTC]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2025-04-25T19:31:57.613Z[Etc/UTC]")
 public class UserSubscriptionOptions {
   private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Update docs to match changes from https://github.com/OneSignal/onesignal-node-api/pull/104. This more clearly describes what each of the configuration keys refer to.