### PR TITLE
ci: use Gradle 7.6 in publish-maven-central workflow

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -24,6 +24,11 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: '7.6'
+
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Changes

ci: use Gradle 7.6 in publish-maven-central workflow