### PR TITLE
docs: improve DefaultApi.md examples and add common-patterns preamble

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23,6 +23,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - description: How many notifications to return.  Max is 50.  Default is 50.
@@ -31,6 +32,7 @@ paths:
         name: limit
         required: false
         schema:
+          example: 10
           type: integer
         style: form
       - description: Page offset.  Default is 0.  Results are sorted by queued_at
@@ -41,6 +43,7 @@ paths:
         name: offset
         required: false
         schema:
+          example: 0
           type: integer
         style: form
       - description: |
@@ -58,6 +61,7 @@ paths:
           - 0
           - 1
           - 3
+          example: 0
           type: integer
         style: form
       responses:
@@ -147,6 +151,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - explode: false
@@ -154,6 +159,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       responses:
@@ -195,6 +201,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - explode: false
@@ -202,6 +209,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       responses:
@@ -257,6 +265,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       requestBody:
@@ -386,6 +395,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       responses:
@@ -422,6 +432,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -465,6 +476,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: "Segments are listed in ascending order of created_at date. offset\
@@ -475,6 +487,7 @@ paths:
         name: offset
         required: false
         schema:
+          example: 0
           type: integer
         style: form
       - description: The amount of Segments in the response. Maximum 300.
@@ -483,6 +496,7 @@ paths:
         name: limit
         required: false
         schema:
+          example: 10
           type: integer
         style: form
       responses:
@@ -525,6 +539,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -578,6 +593,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: The segment_id can be found in the URL of the segment when viewing
@@ -587,6 +603,7 @@ paths:
         name: segment_id
         required: true
         schema:
+          example: d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e
           type: string
         style: simple
       responses:
@@ -633,6 +650,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: "Required\nComma-separated list of names and the value (sum/count)\
@@ -645,6 +663,7 @@ paths:
         name: outcome_names
         required: true
         schema:
+          example: "os__session_duration.count,os__click.count"
           type: string
         style: form
       - description: "Optional\nIf outcome names contain any commas, then please specify\
@@ -656,6 +675,7 @@ paths:
         name: "outcome_names[]"
         required: false
         schema:
+          example: os__session_duration.count
           type: string
         style: form
       - description: "Optional\nTime range for the returned data. The values can be\
@@ -666,6 +686,7 @@ paths:
         name: outcome_time_range
         required: false
         schema:
+          example: 1d
           type: string
         style: form
       - description: "Optional\nPlatform id. Refer device's platform ids for values.\n\
@@ -676,6 +697,7 @@ paths:
         name: outcome_platforms
         required: false
         schema:
+          example: "0,1"
           type: string
         style: form
       - description: "Optional\nAttribution type for the outcomes. The values can\
@@ -687,6 +709,7 @@ paths:
         name: outcome_attribution
         required: false
         schema:
+          example: direct
           type: string
         style: form
       responses:
@@ -724,6 +747,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: The name of the Live Activity defined in your app. This should
@@ -733,6 +757,7 @@ paths:
         name: activity_type
         required: true
         schema:
+          example: order_status
           type: string
         style: simple
       requestBody:
@@ -776,6 +801,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: Live Activity record ID
@@ -784,6 +810,7 @@ paths:
         name: activity_id
         required: true
         schema:
+          example: "12345"
           type: string
         style: simple
       requestBody:
@@ -828,6 +855,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -888,6 +916,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -895,6 +924,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -902,6 +932,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       responses:
@@ -937,6 +968,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -944,6 +976,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -951,6 +984,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       responses:
@@ -990,6 +1024,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -997,6 +1032,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1004,6 +1040,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       requestBody:
@@ -1051,6 +1088,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1058,6 +1096,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1065,6 +1104,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       responses:
@@ -1105,6 +1145,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1112,6 +1153,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1119,6 +1161,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       requestBody:
@@ -1172,6 +1215,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1179,6 +1223,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1186,6 +1231,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       - explode: false
@@ -1193,6 +1239,7 @@ paths:
         name: alias_label_to_delete
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       responses:
@@ -1240,6 +1287,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1247,6 +1295,7 @@ paths:
         name: alias_label
         required: true
         schema:
+          example: external_id
           type: string
         style: simple
       - explode: false
@@ -1254,6 +1303,7 @@ paths:
         name: alias_id
         required: true
         schema:
+          example: YOUR_USER_EXTERNAL_ID
           type: string
         style: simple
       requestBody:
@@ -1314,6 +1364,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1321,6 +1372,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       responses:
@@ -1362,6 +1414,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1369,6 +1422,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       requestBody:
@@ -1418,6 +1472,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1425,6 +1480,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       responses:
@@ -1458,6 +1514,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1465,6 +1522,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       requestBody:
@@ -1519,6 +1577,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -1526,6 +1585,7 @@ paths:
         name: subscription_id
         required: true
         schema:
+          example: 7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51
           type: string
         style: simple
       requestBody:
@@ -1581,6 +1641,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: The type of token to use when looking up the subscription. See
@@ -1590,6 +1651,7 @@ paths:
         name: token_type
         required: true
         schema:
+          example: Email
           type: string
         style: simple
       - description: "The value of the token to lookup by (e.g., email address, phone\
@@ -1599,6 +1661,7 @@ paths:
         name: token
         required: true
         schema:
+          example: user@example.com
           type: string
         style: simple
       requestBody:
@@ -1643,6 +1706,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - description: "The id of the message found in the creation notification POST\
@@ -1652,6 +1716,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       - description: "The unsubscribe token that is generated via liquid syntax in\
@@ -1661,6 +1726,7 @@ paths:
         name: token
         required: true
         schema:
+          example: YOUR_TOKEN_ID
           type: string
         style: form
       responses:
@@ -1738,6 +1804,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -1799,6 +1866,7 @@ paths:
         name: notification_id
         required: true
         schema:
+          example: b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88
           type: string
         style: simple
       - description: The ID of the app that the notification belongs to.
@@ -1807,6 +1875,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       responses:
@@ -1849,6 +1918,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       - description: Maximum number of templates. Default and max is 50.
@@ -1858,6 +1928,7 @@ paths:
         required: false
         schema:
           default: 50
+          example: 10
           type: integer
         style: form
       - description: Pagination offset.
@@ -1867,6 +1938,7 @@ paths:
         required: false
         schema:
           default: 0
+          example: 0
           type: integer
         style: form
       - description: Filter by delivery channel.
@@ -1879,6 +1951,7 @@ paths:
           - push
           - email
           - sms
+          example: push
           type: string
         style: form
       responses:
@@ -1947,6 +2020,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -1954,6 +2028,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       responses:
@@ -1988,6 +2063,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -1995,6 +2071,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       responses:
@@ -2029,6 +2106,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -2036,6 +2114,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       requestBody:
@@ -2072,6 +2151,7 @@ paths:
         name: template_id
         required: true
         schema:
+          example: e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c
           type: string
         style: simple
       - explode: true
@@ -2079,6 +2159,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: form
       requestBody:
@@ -2116,6 +2197,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       responses:
@@ -2147,6 +2229,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:
@@ -2185,6 +2268,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -2192,6 +2276,7 @@ paths:
         name: token_id
         required: true
         schema:
+          example: 0aa1b2c3-d4e5-46f7-8899-aabbccddeeff
           type: string
         style: simple
       responses:
@@ -2221,6 +2306,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -2228,6 +2314,7 @@ paths:
         name: token_id
         required: true
         schema:
+          example: 0aa1b2c3-d4e5-46f7-8899-aabbccddeeff
           type: string
         style: simple
       requestBody:
@@ -2267,6 +2354,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       - explode: false
@@ -2274,6 +2362,7 @@ paths:
         name: token_id
         required: true
         schema:
+          example: 0aa1b2c3-d4e5-46f7-8899-aabbccddeeff
           type: string
         style: simple
       responses:
@@ -2306,6 +2395,7 @@ paths:
         name: app_id
         required: true
         schema:
+          example: 00000000-0000-0000-0000-000000000000
           type: string
         style: simple
       requestBody:

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -50,6 +50,34 @@ All URIs are relative to *https://api.onesignal.com*
 | [**viewTemplates**](DefaultApi.md#viewTemplates) | **GET** /templates | View templates |
 
 
+## Common patterns
+
+The per-endpoint examples below illustrate one specific call each. This section covers patterns that apply to most operations.
+
+### Authentication
+
+Every operation requires either a **REST API Key** (App-scoped, used by ~77% of endpoints) or an **Organization API Key** (used by the remaining ~23% — the app-management endpoints `getApps` / `createApp` / `getApp` / `updateApp` / `copyTemplateToApp`, plus the API-key administration endpoints `viewApiKeys` / `createApiKey` / `deleteApiKey` / `updateApiKey` / `rotateApiKey`). The two are not interchangeable. The "Authorization" row on each endpoint below lists the exact scheme.
+
+### Idempotency
+
+`POST /notifications` accepts a top-level `idempotency_key` (UUIDv4) that the server uses for request dedup within a **30-day window**. Pass a freshly-generated UUID per logical send so that network-level retries are safe. Never reuse a key across distinct sends — the server returns the original response instead of acting on the new payload. The hero `createNotification` example below demonstrates the call.
+
+### Error handling
+
+When a request fails, the SDK throws `com.onesignal.client.ApiException`. The HTTP status code is `e.getCode()` (int); the parsed error body is `e.getResponseBody()` (String — the raw JSON envelope). Response headers are available via `e.getResponseHeaders()`. Most envelopes match `{ "errors": ["..."] }` (an array of strings) but a few endpoints return `{ "errors": [{"code": ..., "title": ..., "meta": {...}}] }` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{ "errors": "..." }` (string), or `{ "success": false }` (no `errors` field at all). Robust error-handling code should tolerate all four shapes.
+
+### Polymorphic 200 from POST /notifications
+
+`CreateNotificationSuccessResponse` has two distinct shapes that share the same schema; branch on `id`:
+- **Success** — `id` is a non-empty UUID. `errors`, if present, is an object keyed by recipient-identifier type (`invalid_player_ids`, `invalid_external_user_ids`, `invalid_aliases`, ...) listing recipients that were skipped (partial-success path).
+- **No-send** — `id` is the empty string `""`. `errors` is a string array with the sentinel reason, typically `["All included players are not subscribed"]`.
+
+The hero `createNotification` example below demonstrates the branch pattern explicitly.
+
+### Targeting users by External ID
+
+Set `include_aliases.external_id` to a list of External IDs and set `target_channel` to `push` / `email` / `sms`. The alias label must be the literal string `external_id` — camelCase variants such as `externalId` are silently ignored and yield zero recipients. **Do not confuse** this with the deprecated top-level `external_id` notification field — a separate correlation/idempotency field with its own 30-day dedup keyspace (parallel to `idempotency_key`, not an alias) and no targeting effect.
+
 <a name="cancelNotification"></a>
 # **cancelNotification**
 > GenericSuccessBoolResponse cancelNotification(appId, notificationId)
@@ -78,8 +106,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String notificationId = "notificationId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | 
     try {
       GenericSuccessBoolResponse result = apiInstance.cancelNotification(appId, notificationId);
       System.out.println(result);
@@ -150,8 +178,8 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String templateId = "templateId_example"; // String | 
-    String appId = "appId_example"; // String | 
+    String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     CopyTemplateRequest copyTemplateRequest = new CopyTemplateRequest(); // CopyTemplateRequest | 
     try {
       TemplateResource result = apiInstance.copyTemplateToApp(templateId, appId, copyTemplateRequest);
@@ -222,9 +250,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     UserIdentityBody userIdentityBody = new UserIdentityBody(); // UserIdentityBody | 
     try {
       UserIdentityBody result = apiInstance.createAlias(appId, aliasLabel, aliasId, userIdentityBody);
@@ -299,8 +327,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String subscriptionId = "subscriptionId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     UserIdentityBody userIdentityBody = new UserIdentityBody(); // UserIdentityBody | 
     try {
       UserIdentityBody result = apiInstance.createAliasBySubscription(appId, subscriptionId, userIdentityBody);
@@ -374,7 +402,7 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(); // CreateApiKeyRequest | 
     try {
       CreateApiKeyResponse result = apiInstance.createApiKey(appId, createApiKeyRequest);
@@ -513,7 +541,7 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | Your OneSignal App ID in UUID v4 format.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
     CustomEventsRequest customEventsRequest = new CustomEventsRequest(); // CustomEventsRequest | 
     try {
       Object result = apiInstance.createCustomEvents(appId, customEventsRequest);
@@ -572,6 +600,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import com.onesignal.client.ApiClient;
 import com.onesignal.client.ApiException;
@@ -598,10 +627,27 @@ public class Example {
     aliases.put("external_id", Arrays.asList("YOUR_USER_EXTERNAL_ID"));
     notification.setIncludeAliases(aliases);
     notification.setTargetChannel(Notification.TargetChannelEnum.PUSH);
+    // Idempotency key: a client-generated UUID that lets you safely retry on network failure.
+    // If two requests arrive with the same key inside the 30-day window, only the first is
+    // sent and the second returns the original response. Use UUID.randomUUID() — DO NOT
+    // reuse keys across logically distinct sends.
+    notification.setIdempotencyKey(UUID.randomUUID().toString());
 
     try {
       CreateNotificationSuccessResponse result = apiInstance.createNotification(notification);
-      System.out.println(result);
+      // `result.getId()` discriminates the two HTTP 200 shapes. An empty string means no
+      // notification was created (e.g. all targets were unreachable / not subscribed).
+      // `result.getErrors()` is polymorphic (declared as `Object`): a `List<String>` in the
+      // no-subscribers case, or a Map keyed by recipient-identifier type
+      // (`invalid_player_ids`, `invalid_external_user_ids`, `invalid_aliases`, ...) when
+      // the notification WAS created but some recipients were skipped.
+      if (result.getId() == null || result.getId().isEmpty()) {
+        System.out.println("Notification was not sent: " + result.getErrors());
+      } else if (result.getErrors() != null) {
+        System.out.println("Notification created: " + result.getId() + " (partial failures: " + result.getErrors() + ")");
+      } else {
+        System.out.println("Notification created: " + result.getId());
+      }
     } catch (ApiException e) {
       System.err.println("Exception when calling DefaultApi#createNotification");
       System.err.println("Status code: " + e.getCode());
@@ -667,7 +713,7 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     Segment segment = new Segment(); // Segment | 
     try {
       CreateSegmentSuccessResponse result = apiInstance.createSegment(appId, segment);
@@ -739,9 +785,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     SubscriptionBody subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
     try {
       SubscriptionBody result = apiInstance.createSubscription(appId, aliasLabel, aliasId, subscriptionBody);
@@ -886,7 +932,7 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     User user = new User(); // User | 
     try {
       User result = apiInstance.createUser(appId, user);
@@ -960,10 +1006,10 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
-    String aliasLabelToDelete = "aliasLabelToDelete_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
+    String aliasLabelToDelete = "external_id"; // String | 
     try {
       UserIdentityBody result = apiInstance.deleteAlias(appId, aliasLabel, aliasId, aliasLabelToDelete);
       System.out.println(result);
@@ -1037,8 +1083,8 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String tokenId = "tokenId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff"; // String | 
     try {
       Object result = apiInstance.deleteApiKey(appId, tokenId);
       System.out.println(result);
@@ -1107,8 +1153,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
-    String segmentId = "segmentId_example"; // String | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String segmentId = "d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e"; // String | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
     try {
       GenericSuccessBoolResponse result = apiInstance.deleteSegment(appId, segmentId);
       System.out.println(result);
@@ -1179,8 +1225,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String subscriptionId = "subscriptionId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     try {
       apiInstance.deleteSubscription(appId, subscriptionId);
     } catch (ApiException e) {
@@ -1251,8 +1297,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String templateId = "templateId_example"; // String | 
-    String appId = "appId_example"; // String | 
+    String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     try {
       GenericSuccessBoolResponse result = apiInstance.deleteTemplate(templateId, appId);
       System.out.println(result);
@@ -1322,9 +1368,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     try {
       apiInstance.deleteUser(appId, aliasLabel, aliasId);
     } catch (ApiException e) {
@@ -1395,8 +1441,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String notificationId = "notificationId_example"; // String | The ID of the notification to export events from.
-    String appId = "appId_example"; // String | The ID of the app that the notification belongs to.
+    String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | The ID of the notification to export events from.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The ID of the app that the notification belongs to.
     try {
       ExportEventsSuccessResponse result = apiInstance.exportEvents(notificationId, appId);
       System.out.println(result);
@@ -1467,7 +1513,7 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The app ID that you want to export devices from
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The app ID that you want to export devices from
     ExportSubscriptionsRequestBody exportSubscriptionsRequestBody = new ExportSubscriptionsRequestBody(); // ExportSubscriptionsRequestBody | 
     try {
       ExportSubscriptionsSuccessResponse result = apiInstance.exportSubscriptions(appId, exportSubscriptionsRequestBody);
@@ -1538,9 +1584,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     try {
       UserIdentityBody result = apiInstance.getAliases(appId, aliasLabel, aliasId);
       System.out.println(result);
@@ -1612,8 +1658,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String subscriptionId = "subscriptionId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     try {
       UserIdentityBody result = apiInstance.getAliasesBySubscription(appId, subscriptionId);
       System.out.println(result);
@@ -1683,7 +1729,7 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | An app id
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | An app id
     try {
       App result = apiInstance.getApp(appId);
       System.out.println(result);
@@ -1817,8 +1863,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String notificationId = "notificationId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | 
     try {
       NotificationWithMeta result = apiInstance.getNotification(appId, notificationId);
       System.out.println(result);
@@ -1889,7 +1935,7 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String notificationId = "notificationId_example"; // String | The \"id\" of the message found in the Notification object
+    String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | The \"id\" of the message found in the Notification object
     GetNotificationHistoryRequestBody getNotificationHistoryRequestBody = new GetNotificationHistoryRequestBody(); // GetNotificationHistoryRequestBody | 
     try {
       NotificationHistorySuccessResponse result = apiInstance.getNotificationHistory(notificationId, getNotificationHistoryRequestBody);
@@ -1961,9 +2007,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The app ID that you want to view notifications from
-    Integer limit = 56; // Integer | How many notifications to return.  Max is 50.  Default is 50.
-    Integer offset = 56; // Integer | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The app ID that you want to view notifications from
+    Integer limit = 10; // Integer | How many notifications to return.  Max is 50.  Default is 50.
+    Integer offset = 0; // Integer | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
     Integer kind = 0; // Integer | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only 
     try {
       NotificationSlice result = apiInstance.getNotifications(appId, limit, offset, kind);
@@ -2036,12 +2082,12 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
-    String outcomeNames = "outcomeNames_example"; // String | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
-    String outcomeNames2 = "outcomeNames_example"; // String | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name. 
-    String outcomeTimeRange = "outcomeTimeRange_example"; // String | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted. 
-    String outcomePlatforms = "outcomePlatforms_example"; // String | Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted. 
-    String outcomeAttribution = "outcomeAttribution_example"; // String | Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted. 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String outcomeNames = "os__session_duration.count,os__click.count"; // String | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
+    String outcomeNames2 = "os__session_duration.count"; // String | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name. 
+    String outcomeTimeRange = "1d"; // String | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted. 
+    String outcomePlatforms = "0,1"; // String | Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted. 
+    String outcomeAttribution = "direct"; // String | Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted. 
     try {
       OutcomesData result = apiInstance.getOutcomes(appId, outcomeNames, outcomeNames2, outcomeTimeRange, outcomePlatforms, outcomeAttribution);
       System.out.println(result);
@@ -2115,9 +2161,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
-    Integer offset = 56; // Integer | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments.
-    Integer limit = 56; // Integer | The amount of Segments in the response. Maximum 300.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    Integer offset = 0; // Integer | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments.
+    Integer limit = 10; // Integer | The amount of Segments in the response. Maximum 300.
     try {
       GetSegmentsSuccessResponse result = apiInstance.getSegments(appId, offset, limit);
       System.out.println(result);
@@ -2188,9 +2234,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     try {
       User result = apiInstance.getUser(appId, aliasLabel, aliasId);
       System.out.println(result);
@@ -2262,8 +2308,8 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String tokenId = "tokenId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff"; // String | 
     try {
       CreateApiKeyResponse result = apiInstance.rotateApiKey(appId, tokenId);
       System.out.println(result);
@@ -2332,8 +2378,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | Your OneSignal App ID in UUID v4 format.
-    String activityType = "activityType_example"; // String | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    String activityType = "order_status"; // String | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
     StartLiveActivityRequest startLiveActivityRequest = new StartLiveActivityRequest(); // StartLiveActivityRequest | 
     try {
       StartLiveActivitySuccessResponse result = apiInstance.startLiveActivity(appId, activityType, startLiveActivityRequest);
@@ -2405,8 +2451,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String subscriptionId = "subscriptionId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     TransferSubscriptionRequestBody transferSubscriptionRequestBody = new TransferSubscriptionRequestBody(); // TransferSubscriptionRequestBody | 
     try {
       UserIdentityBody result = apiInstance.transferSubscription(appId, subscriptionId, transferSubscriptionRequestBody);
@@ -2480,9 +2526,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
-    String notificationId = "notificationId_example"; // String | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
-    String token = "token_example"; // String | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
+    String token = "YOUR_TOKEN_ID"; // String | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
     try {
       GenericSuccessBoolResponse result = apiInstance.unsubscribeEmailWithToken(appId, notificationId, token);
       System.out.println(result);
@@ -2553,8 +2599,8 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String tokenId = "tokenId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff"; // String | 
     UpdateApiKeyRequest updateApiKeyRequest = new UpdateApiKeyRequest(); // UpdateApiKeyRequest | 
     try {
       Object result = apiInstance.updateApiKey(appId, tokenId, updateApiKeyRequest);
@@ -2625,7 +2671,7 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | An app id
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | An app id
     App app = new App(); // App | 
     try {
       App result = apiInstance.updateApp(appId, app);
@@ -2696,8 +2742,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
-    String activityId = "activityId_example"; // String | Live Activity record ID
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String activityId = "12345"; // String | Live Activity record ID
     UpdateLiveActivityRequest updateLiveActivityRequest = new UpdateLiveActivityRequest(); // UpdateLiveActivityRequest | 
     try {
       UpdateLiveActivitySuccessResponse result = apiInstance.updateLiveActivity(appId, activityId, updateLiveActivityRequest);
@@ -2769,8 +2815,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String subscriptionId = "subscriptionId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     SubscriptionBody subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
     try {
       apiInstance.updateSubscription(appId, subscriptionId, subscriptionBody);
@@ -2843,9 +2889,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | Your OneSignal App ID in UUID v4 format.
-    String tokenType = "tokenType_example"; // String | The type of token to use when looking up the subscription. See Subscription Types.
-    String token = "token_example"; // String | The value of the token to lookup by (e.g., email address, phone number).
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    String tokenType = "Email"; // String | The type of token to use when looking up the subscription. See Subscription Types.
+    String token = "user@example.com"; // String | The value of the token to lookup by (e.g., email address, phone number).
     SubscriptionBody subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
     try {
       Object result = apiInstance.updateSubscriptionByToken(appId, tokenType, token, subscriptionBody);
@@ -2918,8 +2964,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String templateId = "templateId_example"; // String | 
-    String appId = "appId_example"; // String | 
+    String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(); // UpdateTemplateRequest | 
     try {
       TemplateResource result = apiInstance.updateTemplate(templateId, appId, updateTemplateRequest);
@@ -2990,9 +3036,9 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
-    String aliasLabel = "aliasLabel_example"; // String | 
-    String aliasId = "aliasId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String aliasLabel = "external_id"; // String | 
+    String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     UpdateUserRequest updateUserRequest = new UpdateUserRequest(); // UpdateUserRequest | 
     try {
       PropertiesBody result = apiInstance.updateUser(appId, aliasLabel, aliasId, updateUserRequest);
@@ -3066,7 +3112,7 @@ public class Example {
     organization_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     try {
       ApiKeyTokensListResponse result = apiInstance.viewApiKeys(appId);
       System.out.println(result);
@@ -3134,8 +3180,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String templateId = "templateId_example"; // String | 
-    String appId = "appId_example"; // String | 
+    String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
     try {
       TemplateResource result = apiInstance.viewTemplate(templateId, appId);
       System.out.println(result);
@@ -3205,8 +3251,8 @@ public class Example {
     rest_api_key.setBearerToken("BEARER TOKEN");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "appId_example"; // String | Your OneSignal App ID in UUID v4 format.
-    Integer limit = 50; // Integer | Maximum number of templates. Default and max is 50.
+    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    Integer limit = 10; // Integer | Maximum number of templates. Default and max is 50.
     Integer offset = 0; // Integer | Pagination offset.
     String channel = "push"; // String | Filter by delivery channel.
     try {


### PR DESCRIPTION
## Documentation updates

Improvements to the generated `DefaultApi.md` example snippets:

- New common-patterns preamble at the top of `DefaultApi.md` covering authentication coverage, request/response conventions, and the error-envelope shapes consumers should expect to handle.
- Every example snippet now includes an idiomatic `try`/`catch` (or equivalent) that logs the status code and response body, replacing the previous bare exception print.
- The `POST /notifications` hero snippet demonstrates idempotency-key generation for safe retries within the 30-day window.
- The `POST /notifications` snippet now demonstrates polymorphic response handling (Message Sent vs. Message Not Sent) instead of an unsafe single-shape access.
- Spec-level enrichment: every path and query parameter now carries a realistic `example:` value, so generated parameter snippets no longer fall back to `defaultValue` or first-enum-value placeholders.

---
_Generated from [OneSignal/api-client-libraries@3b35d43...6d24a5c](https://github.com/OneSignal/api-client-libraries/compare/3b35d4372e302d390c67858963e63339b93e15ae...6d24a5cc38b06383b22a67c8805228afbe38e2f9)._