### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3685,9 +3685,12 @@ components:
         errors: ""
       properties:
         id:
-          description: Notification identifier when the request created a notification.
-            An empty string means no notification was created; read `errors` for details
-            (HTTP may still be 200).
+          description: "Notification identifier when the request created a notification.\
+            \ An empty string means no notification was created; read `errors` for\
+            \ details (HTTP may still be 200). All OneSignal server SDKs expose message-sent\
+            \ / message-not-sent narrowing helpers (named idiomatically per language\
+            \ — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer\
+            \ them over comparing `id` directly."
           type: string
         external_id:
           description: Optional correlation / idempotency-related value from the API

--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -7,7 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **String** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). |  [optional] |
+|**id** | **String** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. |  [optional] |
 |**externalId** | **String** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). |  [optional] |
 |**errors** | **Object** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. |  [optional] |
 

--- a/src/main/java/com/onesignal/client/NotificationHelpers.java
+++ b/src/main/java/com/onesignal/client/NotificationHelpers.java
@@ -103,6 +103,34 @@ public final class NotificationHelpers {
         }
     }
 
+    /**
+     * Whether a POST /notifications 200 response is the "message sent" branch.
+     *
+     * <p>POST /notifications returns 200 in two cases that share the
+     * {@link CreateNotificationSuccessResponse} shape: a notification was
+     * created (non-empty {@code id}), or none was (empty {@code id}, with
+     * {@code errors} carrying the reason). Prefer this guard over inspecting
+     * {@code id} directly.
+     *
+     * @param response a create-notification success response
+     * @return {@code true} when a notification was created
+     */
+    public static boolean isMessageSent(CreateNotificationSuccessResponse response) {
+        return response != null && response.getId() != null && !response.getId().isEmpty();
+    }
+
+    /**
+     * Whether a POST /notifications 200 response is the "message not sent"
+     * branch -- no notification was created ({@code id} absent or empty);
+     * inspect {@code errors} for why.
+     *
+     * @param response a create-notification success response
+     * @return {@code true} when no notification was created
+     */
+    public static boolean isMessageNotSent(CreateNotificationSuccessResponse response) {
+        return !isMessageSent(response);
+    }
+
     private static String headerValue(Map<String, List<String>> headers, String name) {
         if (headers == null) {
             return null;

--- a/src/main/java/com/onesignal/client/model/CreateNotificationSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreateNotificationSuccessResponse.java
@@ -75,11 +75,11 @@ public class CreateNotificationSuccessResponse {
   }
 
    /**
-   * Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200).
+   * Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly.
    * @return id
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).")
+  @ApiModelProperty(value = "Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.")
 
   public String getId() {
     return id;


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4438] type-narrow Java getErrorMessages envelope handling
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...c73114f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...c73114f026690637dccea57b21ee6f0a1eca5051)._