### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -64,7 +64,27 @@ paths:
           example: 0
           type: integer
         style: form
+      - description: "Time-offset pagination cursor for sequential pulls of all messages.\
+          \  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`)\
+          \ or the opaque Base64 cursor token returned as `next_time_offset` in a\
+          \ prior response.  When set, results are sorted ascending by send_after\
+          \ and the standard `offset` parameter cannot be used.  Repeat the request\
+          \ with each `next_time_offset` until an empty notifications array is returned."
+        explode: true
+        in: query
+        name: time_offset
+        required: false
+        schema:
+          example: 2025-01-01T00:00:00.000Z
+          type: string
+        style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -106,6 +126,12 @@ paths:
               $ref: '#/components/schemas/Notification'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -163,6 +189,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -213,6 +245,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -295,6 +333,12 @@ paths:
               type: object
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -329,6 +373,12 @@ paths:
       description: View the details of all of your current OneSignal apps
       operationId: get_apps
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -361,6 +411,12 @@ paths:
               $ref: '#/components/schemas/App'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -399,6 +455,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -442,6 +504,12 @@ paths:
               $ref: '#/components/schemas/App'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -500,6 +568,12 @@ paths:
           type: integer
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "201":
           content:
             application/json:
@@ -549,6 +623,12 @@ paths:
               $ref: '#/components/schemas/Segment'
         required: false
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "201":
           content:
             application/json:
@@ -607,6 +687,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -713,6 +799,12 @@ paths:
           type: string
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -767,6 +859,12 @@ paths:
               $ref: '#/components/schemas/StartLiveActivityRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "201":
           content:
             application/json:
@@ -820,6 +918,12 @@ paths:
               $ref: '#/components/schemas/UpdateLiveActivityRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -865,6 +969,12 @@ paths:
               $ref: '#/components/schemas/User'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -937,6 +1047,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           description: OK
         "400":
@@ -989,6 +1105,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1051,6 +1173,12 @@ paths:
               $ref: '#/components/schemas/UpdateUserRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "202":
           content:
             application/json:
@@ -1109,6 +1237,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1172,6 +1306,12 @@ paths:
               $ref: '#/components/schemas/UserIdentityBody'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1244,6 +1384,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1314,6 +1460,12 @@ paths:
               $ref: '#/components/schemas/SubscriptionBody'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "201":
           content:
             application/json:
@@ -1377,6 +1529,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "202":
           description: ACCEPTED
         "400":
@@ -1433,6 +1591,12 @@ paths:
               $ref: '#/components/schemas/SubscriptionBody'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           description: OK
         "400":
@@ -1485,6 +1649,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1533,6 +1703,12 @@ paths:
               $ref: '#/components/schemas/UserIdentityBody'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1596,6 +1772,12 @@ paths:
               $ref: '#/components/schemas/TransferSubscriptionRequestBody'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1672,6 +1854,12 @@ paths:
               $ref: '#/components/schemas/SubscriptionBody'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "202":
           content:
             application/json:
@@ -1731,6 +1919,12 @@ paths:
           type: string
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "202":
           content:
             application/json:
@@ -1831,6 +2025,12 @@ paths:
               title: export_subscriptions_request_body
               type: object
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1880,6 +2080,12 @@ paths:
           type: string
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1956,6 +2162,12 @@ paths:
           type: string
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -1988,6 +2200,12 @@ paths:
               $ref: '#/components/schemas/CreateTemplateRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2033,6 +2251,12 @@ paths:
           type: string
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2076,6 +2300,12 @@ paths:
           type: string
         style: form
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2125,6 +2355,12 @@ paths:
               $ref: '#/components/schemas/UpdateTemplateRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2170,6 +2406,12 @@ paths:
               $ref: '#/components/schemas/CopyTemplateRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2202,6 +2444,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2240,6 +2488,12 @@ paths:
               $ref: '#/components/schemas/CreateApiKeyRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2281,6 +2535,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2325,6 +2585,12 @@ paths:
               $ref: '#/components/schemas/UpdateApiKeyRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2367,6 +2633,12 @@ paths:
           type: string
         style: simple
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -2406,6 +2678,12 @@ paths:
               $ref: '#/components/schemas/CustomEventsRequest'
         required: true
       responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Unexpected error
         "200":
           content:
             application/json:
@@ -3000,8 +3278,10 @@ components:
     NotificationSlice:
       example:
         offset: 6
+        time_offset: time_offset
         total_count: 0
         limit: 1
+        next_time_offset: next_time_offset
         notifications:
         - null
         - null
@@ -3012,6 +3292,14 @@ components:
           type: integer
         limit:
           type: integer
+        time_offset:
+          description: "The time_offset cursor specified in the request, if any."
+          type: string
+        next_time_offset:
+          description: An opaque Base64 cursor token representing the next page of
+            messages to fetch.  Present when time_offset was provided in the request.  Pass
+            this value as time_offset on the next request to continue paginating.
+          type: string
         notifications:
           items:
             $ref: '#/components/schemas/NotificationWithMeta'
@@ -3685,9 +3973,12 @@ components:
         errors: ""
       properties:
         id:
-          description: Notification identifier when the request created a notification.
-            An empty string means no notification was created; read `errors` for details
-            (HTTP may still be 200).
+          description: "Notification identifier when the request created a notification.\
+            \ An empty string means no notification was created; read `errors` for\
+            \ details (HTTP may still be 200). All OneSignal server SDKs expose message-sent\
+            \ / message-not-sent narrowing helpers (named idiomatically per language\
+            \ — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer\
+            \ them over comparing `id` directly."
           type: string
         external_id:
           description: Optional correlation / idempotency-related value from the API

--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -7,7 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **String** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). |  [optional] |
+|**id** | **String** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. |  [optional] |
 |**externalId** | **String** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). |  [optional] |
 |**errors** | **Object** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. |  [optional] |
 

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -160,6 +160,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="copyTemplateToApp"></a>
 # **copyTemplateToApp**
@@ -235,6 +236,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createAlias"></a>
 # **createAlias**
@@ -315,6 +317,7 @@ public class Example {
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createAliasBySubscription"></a>
 # **createAliasBySubscription**
@@ -393,6 +396,7 @@ public class Example {
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createApiKey"></a>
 # **createApiKey**
@@ -466,6 +470,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createApp"></a>
 # **createApp**
@@ -538,6 +543,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createCustomEvents"></a>
 # **createCustomEvents**
@@ -613,6 +619,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **401** | Unauthorized |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createNotification"></a>
 # **createNotification**
@@ -770,6 +777,7 @@ public class Example {
 | **200** | OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createSegment"></a>
 # **createSegment**
@@ -845,6 +853,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createSubscription"></a>
 # **createSubscription**
@@ -926,6 +935,7 @@ public class Example {
 | **404** | Not Found |  -  |
 | **409** | Operation is not permitted due to user having the maximum number of subscriptions assigned |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createTemplate"></a>
 # **createTemplate**
@@ -998,6 +1008,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **422** | Unprocessable Entity |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="createUser"></a>
 # **createUser**
@@ -1089,6 +1100,7 @@ if (e.getCode() == 409) {
 | **400** | Bad Request |  -  |
 | **409** | Multiple User Identity Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="deleteAlias"></a>
 # **deleteAlias**
@@ -1169,6 +1181,7 @@ public class Example {
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="deleteApiKey"></a>
 # **deleteApiKey**
@@ -1242,6 +1255,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="deleteSegment"></a>
 # **deleteSegment**
@@ -1317,6 +1331,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="deleteSubscription"></a>
 # **deleteSubscription**
@@ -1392,6 +1407,7 @@ null (empty response body)
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="deleteTemplate"></a>
 # **deleteTemplate**
@@ -1466,6 +1482,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="deleteUser"></a>
 # **deleteUser**
@@ -1542,6 +1559,7 @@ null (empty response body)
 | **400** | Bad Request |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="exportEvents"></a>
 # **exportEvents**
@@ -1617,6 +1635,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="exportSubscriptions"></a>
 # **exportSubscriptions**
@@ -1691,6 +1710,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getAliases"></a>
 # **getAliases**
@@ -1768,6 +1788,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getAliasesBySubscription"></a>
 # **getAliasesBySubscription**
@@ -1842,6 +1863,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getApp"></a>
 # **getApp**
@@ -1914,6 +1936,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getApps"></a>
 # **getApps**
@@ -1982,6 +2005,7 @@ This endpoint does not need any parameter.
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getNotification"></a>
 # **getNotification**
@@ -2057,6 +2081,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getNotificationHistory"></a>
 # **getNotificationHistory**
@@ -2132,10 +2157,11 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getNotifications"></a>
 # **getNotifications**
-> NotificationSlice getNotifications(appId, limit, offset, kind)
+> NotificationSlice getNotifications(appId, limit, offset, kind, timeOffset)
 
 View notifications
 
@@ -2165,8 +2191,9 @@ public class Example {
     Integer limit = 10; // Integer | How many notifications to return.  Max is 50.  Default is 50.
     Integer offset = 0; // Integer | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
     Integer kind = 0; // Integer | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only 
+    String timeOffset = "2025-01-01T00:00:00.000Z"; // String | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned.
     try {
-      NotificationSlice result = apiInstance.getNotifications(appId, limit, offset, kind);
+      NotificationSlice result = apiInstance.getNotifications(appId, limit, offset, kind, timeOffset);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling DefaultApi#getNotifications");
@@ -2190,6 +2217,7 @@ public class Example {
 | **limit** | **Integer**| How many notifications to return.  Max is 50.  Default is 50. | [optional] |
 | **offset** | **Integer**| Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | [optional] |
 | **kind** | **Integer**| Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  | [optional] [enum: 0, 1, 3] |
+| **timeOffset** | **String**| Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | [optional] |
 
 ### Return type
 
@@ -2210,6 +2238,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getOutcomes"></a>
 # **getOutcomes**
@@ -2292,6 +2321,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getSegments"></a>
 # **getSegments**
@@ -2368,6 +2398,7 @@ public class Example {
 | **201** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="getUser"></a>
 # **getUser**
@@ -2445,6 +2476,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="rotateApiKey"></a>
 # **rotateApiKey**
@@ -2518,6 +2550,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="startLiveActivity"></a>
 # **startLiveActivity**
@@ -2594,6 +2627,7 @@ public class Example {
 | **201** | Created |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="transferSubscription"></a>
 # **transferSubscription**
@@ -2672,6 +2706,7 @@ public class Example {
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="unsubscribeEmailWithToken"></a>
 # **unsubscribeEmailWithToken**
@@ -2748,6 +2783,7 @@ public class Example {
 | **202** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateApiKey"></a>
 # **updateApiKey**
@@ -2823,6 +2859,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateApp"></a>
 # **updateApp**
@@ -2897,6 +2934,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateLiveActivity"></a>
 # **updateLiveActivity**
@@ -2973,6 +3011,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateSubscription"></a>
 # **updateSubscription**
@@ -3050,6 +3089,7 @@ null (empty response body)
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateSubscriptionByToken"></a>
 # **updateSubscriptionByToken**
@@ -3128,6 +3168,7 @@ public class Example {
 | **202** | ACCEPTED |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateTemplate"></a>
 # **updateTemplate**
@@ -3203,6 +3244,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="updateUser"></a>
 # **updateUser**
@@ -3282,6 +3324,7 @@ public class Example {
 | **400** | Bad Request |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="viewApiKeys"></a>
 # **viewApiKeys**
@@ -3353,6 +3396,7 @@ public class Example {
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="viewTemplate"></a>
 # **viewTemplate**
@@ -3427,6 +3471,7 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 <a name="viewTemplates"></a>
 # **viewTemplates**
@@ -3505,4 +3550,5 @@ public class Example {
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -10,6 +10,8 @@
 |**totalCount** | **Integer** |  |  [optional] |
 |**offset** | **Integer** |  |  [optional] |
 |**limit** | **Integer** |  |  [optional] |
+|**timeOffset** | **String** | The time_offset cursor specified in the request, if any. |  [optional] |
+|**nextTimeOffset** | **String** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. |  [optional] |
 |**notifications** | [**List&lt;NotificationWithMeta&gt;**](NotificationWithMeta.md) |  |  [optional] |
 
 

--- a/src/main/java/com/onesignal/client/NotificationHelpers.java
+++ b/src/main/java/com/onesignal/client/NotificationHelpers.java
@@ -103,6 +103,34 @@ public final class NotificationHelpers {
         }
     }
 
+    /**
+     * Whether a POST /notifications 200 response is the "message sent" branch.
+     *
+     * <p>POST /notifications returns 200 in two cases that share the
+     * {@link CreateNotificationSuccessResponse} shape: a notification was
+     * created (non-empty {@code id}), or none was (empty {@code id}, with
+     * {@code errors} carrying the reason). Prefer this guard over inspecting
+     * {@code id} directly.
+     *
+     * @param response a create-notification success response
+     * @return {@code true} when a notification was created
+     */
+    public static boolean isMessageSent(CreateNotificationSuccessResponse response) {
+        return response != null && response.getId() != null && !response.getId().isEmpty();
+    }
+
+    /**
+     * Whether a POST /notifications 200 response is the "message not sent"
+     * branch -- no notification was created ({@code id} absent or empty);
+     * inspect {@code errors} for why.
+     *
+     * @param response a create-notification success response
+     * @return {@code true} when no notification was created
+     */
+    public static boolean isMessageNotSent(CreateNotificationSuccessResponse response) {
+        return !isMessageSent(response);
+    }
+
     private static String headerValue(Map<String, List<String>> headers, String name) {
         if (headers == null) {
             return null;

--- a/src/main/java/com/onesignal/client/api/DefaultApi.java
+++ b/src/main/java/com/onesignal/client/api/DefaultApi.java
@@ -125,6 +125,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call cancelNotificationCall(String appId, String notificationId, final ApiCallback _callback) throws ApiException {
@@ -213,6 +214,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public GenericSuccessBoolResponse cancelNotification(String appId, String notificationId) throws ApiException {
@@ -234,6 +236,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<GenericSuccessBoolResponse> cancelNotificationWithHttpInfo(String appId, String notificationId) throws ApiException {
@@ -257,6 +260,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call cancelNotificationAsync(String appId, String notificationId, final ApiCallback<GenericSuccessBoolResponse> _callback) throws ApiException {
@@ -279,6 +283,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call copyTemplateToAppCall(String templateId, String appId, CopyTemplateRequest copyTemplateRequest, final ApiCallback _callback) throws ApiException {
@@ -371,6 +376,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public TemplateResource copyTemplateToApp(String templateId, String appId, CopyTemplateRequest copyTemplateRequest) throws ApiException {
@@ -391,6 +397,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<TemplateResource> copyTemplateToAppWithHttpInfo(String templateId, String appId, CopyTemplateRequest copyTemplateRequest) throws ApiException {
@@ -413,6 +420,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call copyTemplateToAppAsync(String templateId, String appId, CopyTemplateRequest copyTemplateRequest, final ApiCallback<TemplateResource> _callback) throws ApiException {
@@ -439,6 +447,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createAliasCall(String appId, String aliasLabel, String aliasId, UserIdentityBody userIdentityBody, final ApiCallback _callback) throws ApiException {
@@ -538,6 +547,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UserIdentityBody createAlias(String appId, String aliasLabel, String aliasId, UserIdentityBody userIdentityBody) throws ApiException {
@@ -562,6 +572,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UserIdentityBody> createAliasWithHttpInfo(String appId, String aliasLabel, String aliasId, UserIdentityBody userIdentityBody) throws ApiException {
@@ -588,6 +599,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createAliasAsync(String appId, String aliasLabel, String aliasId, UserIdentityBody userIdentityBody, final ApiCallback<UserIdentityBody> _callback) throws ApiException {
@@ -613,6 +625,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createAliasBySubscriptionCall(String appId, String subscriptionId, UserIdentityBody userIdentityBody, final ApiCallback _callback) throws ApiException {
@@ -705,6 +718,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UserIdentityBody createAliasBySubscription(String appId, String subscriptionId, UserIdentityBody userIdentityBody) throws ApiException {
@@ -728,6 +742,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UserIdentityBody> createAliasBySubscriptionWithHttpInfo(String appId, String subscriptionId, UserIdentityBody userIdentityBody) throws ApiException {
@@ -753,6 +768,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createAliasBySubscriptionAsync(String appId, String subscriptionId, UserIdentityBody userIdentityBody, final ApiCallback<UserIdentityBody> _callback) throws ApiException {
@@ -774,6 +790,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createApiKeyCall(String appId, CreateApiKeyRequest createApiKeyRequest, final ApiCallback _callback) throws ApiException {
@@ -856,6 +873,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public CreateApiKeyResponse createApiKey(String appId, CreateApiKeyRequest createApiKeyRequest) throws ApiException {
@@ -875,6 +893,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CreateApiKeyResponse> createApiKeyWithHttpInfo(String appId, CreateApiKeyRequest createApiKeyRequest) throws ApiException {
@@ -896,6 +915,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createApiKeyAsync(String appId, CreateApiKeyRequest createApiKeyRequest, final ApiCallback<CreateApiKeyResponse> _callback) throws ApiException {
@@ -917,6 +937,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createAppCall(App app, final ApiCallback _callback) throws ApiException {
@@ -993,6 +1014,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public App createApp(App app) throws ApiException {
@@ -1012,6 +1034,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<App> createAppWithHttpInfo(App app) throws ApiException {
@@ -1033,6 +1056,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createAppAsync(App app, final ApiCallback<App> _callback) throws ApiException {
@@ -1056,6 +1080,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createCustomEventsCall(String appId, CustomEventsRequest customEventsRequest, final ApiCallback _callback) throws ApiException {
@@ -1140,6 +1165,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public Object createCustomEvents(String appId, CustomEventsRequest customEventsRequest) throws ApiException {
@@ -1161,6 +1187,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Object> createCustomEventsWithHttpInfo(String appId, CustomEventsRequest customEventsRequest) throws ApiException {
@@ -1184,6 +1211,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createCustomEventsAsync(String appId, CustomEventsRequest customEventsRequest, final ApiCallback<Object> _callback) throws ApiException {
@@ -1205,6 +1233,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createNotificationCall(Notification notification, final ApiCallback _callback) throws ApiException {
@@ -1281,6 +1310,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public CreateNotificationSuccessResponse createNotification(Notification notification) throws ApiException {
@@ -1300,6 +1330,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CreateNotificationSuccessResponse> createNotificationWithHttpInfo(Notification notification) throws ApiException {
@@ -1321,6 +1352,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createNotificationAsync(Notification notification, final ApiCallback<CreateNotificationSuccessResponse> _callback) throws ApiException {
@@ -1344,6 +1376,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSegmentCall(String appId, Segment segment, final ApiCallback _callback) throws ApiException {
@@ -1423,6 +1456,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public CreateSegmentSuccessResponse createSegment(String appId, Segment segment) throws ApiException {
@@ -1444,6 +1478,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CreateSegmentSuccessResponse> createSegmentWithHttpInfo(String appId, Segment segment) throws ApiException {
@@ -1467,6 +1502,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSegmentAsync(String appId, Segment segment, final ApiCallback<CreateSegmentSuccessResponse> _callback) throws ApiException {
@@ -1494,6 +1530,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Operation is not permitted due to user having the maximum number of subscriptions assigned </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSubscriptionCall(String appId, String aliasLabel, String aliasId, SubscriptionBody subscriptionBody, final ApiCallback _callback) throws ApiException {
@@ -1594,6 +1631,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Operation is not permitted due to user having the maximum number of subscriptions assigned </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public SubscriptionBody createSubscription(String appId, String aliasLabel, String aliasId, SubscriptionBody subscriptionBody) throws ApiException {
@@ -1619,6 +1657,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Operation is not permitted due to user having the maximum number of subscriptions assigned </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<SubscriptionBody> createSubscriptionWithHttpInfo(String appId, String aliasLabel, String aliasId, SubscriptionBody subscriptionBody) throws ApiException {
@@ -1646,6 +1685,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Operation is not permitted due to user having the maximum number of subscriptions assigned </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createSubscriptionAsync(String appId, String aliasLabel, String aliasId, SubscriptionBody subscriptionBody, final ApiCallback<SubscriptionBody> _callback) throws ApiException {
@@ -1667,6 +1707,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable Entity </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createTemplateCall(CreateTemplateRequest createTemplateRequest, final ApiCallback _callback) throws ApiException {
@@ -1743,6 +1784,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable Entity </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public TemplateResource createTemplate(CreateTemplateRequest createTemplateRequest) throws ApiException {
@@ -1762,6 +1804,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable Entity </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<TemplateResource> createTemplateWithHttpInfo(CreateTemplateRequest createTemplateRequest) throws ApiException {
@@ -1783,6 +1826,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 422 </td><td> Unprocessable Entity </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createTemplateAsync(CreateTemplateRequest createTemplateRequest, final ApiCallback<TemplateResource> _callback) throws ApiException {
@@ -1808,6 +1852,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Multiple User Identity Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createUserCall(String appId, User user, final ApiCallback _callback) throws ApiException {
@@ -1894,6 +1939,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Multiple User Identity Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public User createUser(String appId, User user) throws ApiException {
@@ -1917,6 +1963,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Multiple User Identity Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<User> createUserWithHttpInfo(String appId, User user) throws ApiException {
@@ -1942,6 +1989,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Multiple User Identity Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call createUserAsync(String appId, User user, final ApiCallback<User> _callback) throws ApiException {
@@ -1968,6 +2016,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteAliasCall(String appId, String aliasLabel, String aliasId, String aliasLabelToDelete, final ApiCallback _callback) throws ApiException {
@@ -2068,6 +2117,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UserIdentityBody deleteAlias(String appId, String aliasLabel, String aliasId, String aliasLabelToDelete) throws ApiException {
@@ -2092,6 +2142,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UserIdentityBody> deleteAliasWithHttpInfo(String appId, String aliasLabel, String aliasId, String aliasLabelToDelete) throws ApiException {
@@ -2118,6 +2169,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteAliasAsync(String appId, String aliasLabel, String aliasId, String aliasLabelToDelete, final ApiCallback<UserIdentityBody> _callback) throws ApiException {
@@ -2139,6 +2191,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteApiKeyCall(String appId, String tokenId, final ApiCallback _callback) throws ApiException {
@@ -2222,6 +2275,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public Object deleteApiKey(String appId, String tokenId) throws ApiException {
@@ -2241,6 +2295,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Object> deleteApiKeyWithHttpInfo(String appId, String tokenId) throws ApiException {
@@ -2262,6 +2317,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteApiKeyAsync(String appId, String tokenId, final ApiCallback<Object> _callback) throws ApiException {
@@ -2285,6 +2341,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteSegmentCall(String appId, String segmentId, final ApiCallback _callback) throws ApiException {
@@ -2370,6 +2427,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public GenericSuccessBoolResponse deleteSegment(String appId, String segmentId) throws ApiException {
@@ -2391,6 +2449,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<GenericSuccessBoolResponse> deleteSegmentWithHttpInfo(String appId, String segmentId) throws ApiException {
@@ -2414,6 +2473,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteSegmentAsync(String appId, String segmentId, final ApiCallback<GenericSuccessBoolResponse> _callback) throws ApiException {
@@ -2438,6 +2498,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteSubscriptionCall(String appId, String subscriptionId, final ApiCallback _callback) throws ApiException {
@@ -2523,6 +2584,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public void deleteSubscription(String appId, String subscriptionId) throws ApiException {
@@ -2544,6 +2606,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Void> deleteSubscriptionWithHttpInfo(String appId, String subscriptionId) throws ApiException {
@@ -2567,6 +2630,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteSubscriptionAsync(String appId, String subscriptionId, final ApiCallback<Void> _callback) throws ApiException {
@@ -2588,6 +2652,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteTemplateCall(String templateId, String appId, final ApiCallback _callback) throws ApiException {
@@ -2675,6 +2740,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public GenericSuccessBoolResponse deleteTemplate(String templateId, String appId) throws ApiException {
@@ -2695,6 +2761,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<GenericSuccessBoolResponse> deleteTemplateWithHttpInfo(String templateId, String appId) throws ApiException {
@@ -2717,6 +2784,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteTemplateAsync(String templateId, String appId, final ApiCallback<GenericSuccessBoolResponse> _callback) throws ApiException {
@@ -2741,6 +2809,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteUserCall(String appId, String aliasLabel, String aliasId, final ApiCallback _callback) throws ApiException {
@@ -2832,6 +2901,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public void deleteUser(String appId, String aliasLabel, String aliasId) throws ApiException {
@@ -2853,6 +2923,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Void> deleteUserWithHttpInfo(String appId, String aliasLabel, String aliasId) throws ApiException {
@@ -2876,6 +2947,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call deleteUserAsync(String appId, String aliasLabel, String aliasId, final ApiCallback<Void> _callback) throws ApiException {
@@ -2898,6 +2970,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call exportEventsCall(String notificationId, String appId, final ApiCallback _callback) throws ApiException {
@@ -2986,6 +3059,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ExportEventsSuccessResponse exportEvents(String notificationId, String appId) throws ApiException {
@@ -3007,6 +3081,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<ExportEventsSuccessResponse> exportEventsWithHttpInfo(String notificationId, String appId) throws ApiException {
@@ -3030,6 +3105,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call exportEventsAsync(String notificationId, String appId, final ApiCallback<ExportEventsSuccessResponse> _callback) throws ApiException {
@@ -3052,6 +3128,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call exportSubscriptionsCall(String appId, ExportSubscriptionsRequestBody exportSubscriptionsRequestBody, final ApiCallback _callback) throws ApiException {
@@ -3130,6 +3207,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ExportSubscriptionsSuccessResponse exportSubscriptions(String appId, ExportSubscriptionsRequestBody exportSubscriptionsRequestBody) throws ApiException {
@@ -3150,6 +3228,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<ExportSubscriptionsSuccessResponse> exportSubscriptionsWithHttpInfo(String appId, ExportSubscriptionsRequestBody exportSubscriptionsRequestBody) throws ApiException {
@@ -3172,6 +3251,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call exportSubscriptionsAsync(String appId, ExportSubscriptionsRequestBody exportSubscriptionsRequestBody, final ApiCallback<ExportSubscriptionsSuccessResponse> _callback) throws ApiException {
@@ -3196,6 +3276,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAliasesCall(String appId, String aliasLabel, String aliasId, final ApiCallback _callback) throws ApiException {
@@ -3288,6 +3369,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UserIdentityBody getAliases(String appId, String aliasLabel, String aliasId) throws ApiException {
@@ -3310,6 +3392,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UserIdentityBody> getAliasesWithHttpInfo(String appId, String aliasLabel, String aliasId) throws ApiException {
@@ -3334,6 +3417,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAliasesAsync(String appId, String aliasLabel, String aliasId, final ApiCallback<UserIdentityBody> _callback) throws ApiException {
@@ -3356,6 +3440,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAliasesBySubscriptionCall(String appId, String subscriptionId, final ApiCallback _callback) throws ApiException {
@@ -3440,6 +3525,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UserIdentityBody getAliasesBySubscription(String appId, String subscriptionId) throws ApiException {
@@ -3460,6 +3546,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UserIdentityBody> getAliasesBySubscriptionWithHttpInfo(String appId, String subscriptionId) throws ApiException {
@@ -3482,6 +3569,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAliasesBySubscriptionAsync(String appId, String subscriptionId, final ApiCallback<UserIdentityBody> _callback) throws ApiException {
@@ -3503,6 +3591,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAppCall(String appId, final ApiCallback _callback) throws ApiException {
@@ -3580,6 +3669,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public App getApp(String appId) throws ApiException {
@@ -3599,6 +3689,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<App> getAppWithHttpInfo(String appId) throws ApiException {
@@ -3620,6 +3711,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAppAsync(String appId, final ApiCallback<App> _callback) throws ApiException {
@@ -3640,6 +3732,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAppsCall(final ApiCallback _callback) throws ApiException {
@@ -3710,6 +3803,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public List<App> getApps() throws ApiException {
@@ -3728,6 +3822,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<List<App>> getAppsWithHttpInfo() throws ApiException {
@@ -3748,6 +3843,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getAppsAsync(final ApiCallback<List<App>> _callback) throws ApiException {
@@ -3771,6 +3867,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getNotificationCall(String appId, String notificationId, final ApiCallback _callback) throws ApiException {
@@ -3859,6 +3956,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public NotificationWithMeta getNotification(String appId, String notificationId) throws ApiException {
@@ -3880,6 +3978,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<NotificationWithMeta> getNotificationWithHttpInfo(String appId, String notificationId) throws ApiException {
@@ -3903,6 +4002,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getNotificationAsync(String appId, String notificationId, final ApiCallback<NotificationWithMeta> _callback) throws ApiException {
@@ -3926,6 +4026,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getNotificationHistoryCall(String notificationId, GetNotificationHistoryRequestBody getNotificationHistoryRequestBody, final ApiCallback _callback) throws ApiException {
@@ -4010,6 +4111,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public NotificationHistorySuccessResponse getNotificationHistory(String notificationId, GetNotificationHistoryRequestBody getNotificationHistoryRequestBody) throws ApiException {
@@ -4031,6 +4133,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<NotificationHistorySuccessResponse> getNotificationHistoryWithHttpInfo(String notificationId, GetNotificationHistoryRequestBody getNotificationHistoryRequestBody) throws ApiException {
@@ -4054,6 +4157,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getNotificationHistoryAsync(String notificationId, GetNotificationHistoryRequestBody getNotificationHistoryRequestBody, final ApiCallback<NotificationHistorySuccessResponse> _callback) throws ApiException {
@@ -4069,6 +4173,7 @@ public class DefaultApi {
      * @param limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)
+     * @param timeOffset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -4078,9 +4183,10 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getNotificationsCall(String appId, Integer limit, Integer offset, Integer kind, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getNotificationsCall(String appId, Integer limit, Integer offset, Integer kind, String timeOffset, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -4124,6 +4230,10 @@ public class DefaultApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("kind", kind));
         }
 
+        if (timeOffset != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("time_offset", timeOffset));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -4145,7 +4255,7 @@ public class DefaultApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getNotificationsValidateBeforeCall(String appId, Integer limit, Integer offset, Integer kind, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getNotificationsValidateBeforeCall(String appId, Integer limit, Integer offset, Integer kind, String timeOffset, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'appId' is set
         if (appId == null) {
@@ -4153,7 +4263,7 @@ public class DefaultApi {
         }
         
 
-        okhttp3.Call localVarCall = getNotificationsCall(appId, limit, offset, kind, _callback);
+        okhttp3.Call localVarCall = getNotificationsCall(appId, limit, offset, kind, timeOffset, _callback);
         return localVarCall;
 
     }
@@ -4165,6 +4275,7 @@ public class DefaultApi {
      * @param limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)
+     * @param timeOffset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      * @return NotificationSlice
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -4173,10 +4284,11 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public NotificationSlice getNotifications(String appId, Integer limit, Integer offset, Integer kind) throws ApiException {
-        ApiResponse<NotificationSlice> localVarResp = getNotificationsWithHttpInfo(appId, limit, offset, kind);
+    public NotificationSlice getNotifications(String appId, Integer limit, Integer offset, Integer kind, String timeOffset) throws ApiException {
+        ApiResponse<NotificationSlice> localVarResp = getNotificationsWithHttpInfo(appId, limit, offset, kind, timeOffset);
         return localVarResp.getData();
     }
 
@@ -4187,6 +4299,7 @@ public class DefaultApi {
      * @param limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)
+     * @param timeOffset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      * @return ApiResponse&lt;NotificationSlice&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -4195,10 +4308,11 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<NotificationSlice> getNotificationsWithHttpInfo(String appId, Integer limit, Integer offset, Integer kind) throws ApiException {
-        okhttp3.Call localVarCall = getNotificationsValidateBeforeCall(appId, limit, offset, kind, null);
+    public ApiResponse<NotificationSlice> getNotificationsWithHttpInfo(String appId, Integer limit, Integer offset, Integer kind, String timeOffset) throws ApiException {
+        okhttp3.Call localVarCall = getNotificationsValidateBeforeCall(appId, limit, offset, kind, timeOffset, null);
         Type localVarReturnType = new TypeToken<NotificationSlice>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -4210,6 +4324,7 @@ public class DefaultApi {
      * @param limit How many notifications to return.  Max is 50.  Default is 50. (optional)
      * @param offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)
      * @param kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)
+     * @param timeOffset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -4219,11 +4334,12 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getNotificationsAsync(String appId, Integer limit, Integer offset, Integer kind, final ApiCallback<NotificationSlice> _callback) throws ApiException {
+    public okhttp3.Call getNotificationsAsync(String appId, Integer limit, Integer offset, Integer kind, String timeOffset, final ApiCallback<NotificationSlice> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getNotificationsValidateBeforeCall(appId, limit, offset, kind, _callback);
+        okhttp3.Call localVarCall = getNotificationsValidateBeforeCall(appId, limit, offset, kind, timeOffset, _callback);
         Type localVarReturnType = new TypeToken<NotificationSlice>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
@@ -4245,6 +4361,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getOutcomesCall(String appId, String outcomeNames, String outcomeNames2, String outcomeTimeRange, String outcomePlatforms, String outcomeAttribution, final ApiCallback _callback) throws ApiException {
@@ -4352,6 +4469,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public OutcomesData getOutcomes(String appId, String outcomeNames, String outcomeNames2, String outcomeTimeRange, String outcomePlatforms, String outcomeAttribution) throws ApiException {
@@ -4376,6 +4494,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<OutcomesData> getOutcomesWithHttpInfo(String appId, String outcomeNames, String outcomeNames2, String outcomeTimeRange, String outcomePlatforms, String outcomeAttribution) throws ApiException {
@@ -4402,6 +4521,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getOutcomesAsync(String appId, String outcomeNames, String outcomeNames2, String outcomeTimeRange, String outcomePlatforms, String outcomeAttribution, final ApiCallback<OutcomesData> _callback) throws ApiException {
@@ -4425,6 +4545,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getSegmentsCall(String appId, Integer offset, Integer limit, final ApiCallback _callback) throws ApiException {
@@ -4512,6 +4633,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public GetSegmentsSuccessResponse getSegments(String appId, Integer offset, Integer limit) throws ApiException {
@@ -4533,6 +4655,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<GetSegmentsSuccessResponse> getSegmentsWithHttpInfo(String appId, Integer offset, Integer limit) throws ApiException {
@@ -4556,6 +4679,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getSegmentsAsync(String appId, Integer offset, Integer limit, final ApiCallback<GetSegmentsSuccessResponse> _callback) throws ApiException {
@@ -4580,6 +4704,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getUserCall(String appId, String aliasLabel, String aliasId, final ApiCallback _callback) throws ApiException {
@@ -4672,6 +4797,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public User getUser(String appId, String aliasLabel, String aliasId) throws ApiException {
@@ -4694,6 +4820,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<User> getUserWithHttpInfo(String appId, String aliasLabel, String aliasId) throws ApiException {
@@ -4718,6 +4845,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call getUserAsync(String appId, String aliasLabel, String aliasId, final ApiCallback<User> _callback) throws ApiException {
@@ -4739,6 +4867,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call rotateApiKeyCall(String appId, String tokenId, final ApiCallback _callback) throws ApiException {
@@ -4822,6 +4951,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public CreateApiKeyResponse rotateApiKey(String appId, String tokenId) throws ApiException {
@@ -4841,6 +4971,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<CreateApiKeyResponse> rotateApiKeyWithHttpInfo(String appId, String tokenId) throws ApiException {
@@ -4862,6 +4993,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call rotateApiKeyAsync(String appId, String tokenId, final ApiCallback<CreateApiKeyResponse> _callback) throws ApiException {
@@ -4885,6 +5017,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call startLiveActivityCall(String appId, String activityType, StartLiveActivityRequest startLiveActivityRequest, final ApiCallback _callback) throws ApiException {
@@ -4975,6 +5108,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public StartLiveActivitySuccessResponse startLiveActivity(String appId, String activityType, StartLiveActivityRequest startLiveActivityRequest) throws ApiException {
@@ -4996,6 +5130,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<StartLiveActivitySuccessResponse> startLiveActivityWithHttpInfo(String appId, String activityType, StartLiveActivityRequest startLiveActivityRequest) throws ApiException {
@@ -5019,6 +5154,7 @@ public class DefaultApi {
         <tr><td> 201 </td><td> Created </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call startLiveActivityAsync(String appId, String activityType, StartLiveActivityRequest startLiveActivityRequest, final ApiCallback<StartLiveActivitySuccessResponse> _callback) throws ApiException {
@@ -5044,6 +5180,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call transferSubscriptionCall(String appId, String subscriptionId, TransferSubscriptionRequestBody transferSubscriptionRequestBody, final ApiCallback _callback) throws ApiException {
@@ -5136,6 +5273,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UserIdentityBody transferSubscription(String appId, String subscriptionId, TransferSubscriptionRequestBody transferSubscriptionRequestBody) throws ApiException {
@@ -5159,6 +5297,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UserIdentityBody> transferSubscriptionWithHttpInfo(String appId, String subscriptionId, TransferSubscriptionRequestBody transferSubscriptionRequestBody) throws ApiException {
@@ -5184,6 +5323,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call transferSubscriptionAsync(String appId, String subscriptionId, TransferSubscriptionRequestBody transferSubscriptionRequestBody, final ApiCallback<UserIdentityBody> _callback) throws ApiException {
@@ -5207,6 +5347,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call unsubscribeEmailWithTokenCall(String appId, String notificationId, String token, final ApiCallback _callback) throws ApiException {
@@ -5301,6 +5442,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public GenericSuccessBoolResponse unsubscribeEmailWithToken(String appId, String notificationId, String token) throws ApiException {
@@ -5322,6 +5464,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<GenericSuccessBoolResponse> unsubscribeEmailWithTokenWithHttpInfo(String appId, String notificationId, String token) throws ApiException {
@@ -5345,6 +5488,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call unsubscribeEmailWithTokenAsync(String appId, String notificationId, String token, final ApiCallback<GenericSuccessBoolResponse> _callback) throws ApiException {
@@ -5367,6 +5511,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateApiKeyCall(String appId, String tokenId, UpdateApiKeyRequest updateApiKeyRequest, final ApiCallback _callback) throws ApiException {
@@ -5456,6 +5601,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public Object updateApiKey(String appId, String tokenId, UpdateApiKeyRequest updateApiKeyRequest) throws ApiException {
@@ -5476,6 +5622,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Object> updateApiKeyWithHttpInfo(String appId, String tokenId, UpdateApiKeyRequest updateApiKeyRequest) throws ApiException {
@@ -5498,6 +5645,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateApiKeyAsync(String appId, String tokenId, UpdateApiKeyRequest updateApiKeyRequest, final ApiCallback<Object> _callback) throws ApiException {
@@ -5520,6 +5668,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateAppCall(String appId, App app, final ApiCallback _callback) throws ApiException {
@@ -5603,6 +5752,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public App updateApp(String appId, App app) throws ApiException {
@@ -5623,6 +5773,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<App> updateAppWithHttpInfo(String appId, App app) throws ApiException {
@@ -5645,6 +5796,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateAppAsync(String appId, App app, final ApiCallback<App> _callback) throws ApiException {
@@ -5668,6 +5820,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateLiveActivityCall(String appId, String activityId, UpdateLiveActivityRequest updateLiveActivityRequest, final ApiCallback _callback) throws ApiException {
@@ -5758,6 +5911,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public UpdateLiveActivitySuccessResponse updateLiveActivity(String appId, String activityId, UpdateLiveActivityRequest updateLiveActivityRequest) throws ApiException {
@@ -5779,6 +5933,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<UpdateLiveActivitySuccessResponse> updateLiveActivityWithHttpInfo(String appId, String activityId, UpdateLiveActivityRequest updateLiveActivityRequest) throws ApiException {
@@ -5802,6 +5957,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateLiveActivityAsync(String appId, String activityId, UpdateLiveActivityRequest updateLiveActivityRequest, final ApiCallback<UpdateLiveActivitySuccessResponse> _callback) throws ApiException {
@@ -5827,6 +5983,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateSubscriptionCall(String appId, String subscriptionId, SubscriptionBody subscriptionBody, final ApiCallback _callback) throws ApiException {
@@ -5918,6 +6075,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public void updateSubscription(String appId, String subscriptionId, SubscriptionBody subscriptionBody) throws ApiException {
@@ -5940,6 +6098,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Void> updateSubscriptionWithHttpInfo(String appId, String subscriptionId, SubscriptionBody subscriptionBody) throws ApiException {
@@ -5964,6 +6123,7 @@ public class DefaultApi {
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateSubscriptionAsync(String appId, String subscriptionId, SubscriptionBody subscriptionBody, final ApiCallback<Void> _callback) throws ApiException {
@@ -5987,6 +6147,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> ACCEPTED </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateSubscriptionByTokenCall(String appId, String tokenType, String token, SubscriptionBody subscriptionBody, final ApiCallback _callback) throws ApiException {
@@ -6084,6 +6245,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> ACCEPTED </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public Object updateSubscriptionByToken(String appId, String tokenType, String token, SubscriptionBody subscriptionBody) throws ApiException {
@@ -6106,6 +6268,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> ACCEPTED </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<Object> updateSubscriptionByTokenWithHttpInfo(String appId, String tokenType, String token, SubscriptionBody subscriptionBody) throws ApiException {
@@ -6130,6 +6293,7 @@ public class DefaultApi {
         <tr><td> 202 </td><td> ACCEPTED </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateSubscriptionByTokenAsync(String appId, String tokenType, String token, SubscriptionBody subscriptionBody, final ApiCallback<Object> _callback) throws ApiException {
@@ -6152,6 +6316,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateTemplateCall(String templateId, String appId, UpdateTemplateRequest updateTemplateRequest, final ApiCallback _callback) throws ApiException {
@@ -6244,6 +6409,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public TemplateResource updateTemplate(String templateId, String appId, UpdateTemplateRequest updateTemplateRequest) throws ApiException {
@@ -6264,6 +6430,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<TemplateResource> updateTemplateWithHttpInfo(String templateId, String appId, UpdateTemplateRequest updateTemplateRequest) throws ApiException {
@@ -6286,6 +6453,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateTemplateAsync(String templateId, String appId, UpdateTemplateRequest updateTemplateRequest, final ApiCallback<TemplateResource> _callback) throws ApiException {
@@ -6311,6 +6479,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateUserCall(String appId, String aliasLabel, String aliasId, UpdateUserRequest updateUserRequest, final ApiCallback _callback) throws ApiException {
@@ -6409,6 +6578,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public PropertiesBody updateUser(String appId, String aliasLabel, String aliasId, UpdateUserRequest updateUserRequest) throws ApiException {
@@ -6432,6 +6602,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<PropertiesBody> updateUserWithHttpInfo(String appId, String aliasLabel, String aliasId, UpdateUserRequest updateUserRequest) throws ApiException {
@@ -6457,6 +6628,7 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> Conflict </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call updateUserAsync(String appId, String aliasLabel, String aliasId, UpdateUserRequest updateUserRequest, final ApiCallback<PropertiesBody> _callback) throws ApiException {
@@ -6477,6 +6649,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call viewApiKeysCall(String appId, final ApiCallback _callback) throws ApiException {
@@ -6553,6 +6726,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiKeyTokensListResponse viewApiKeys(String appId) throws ApiException {
@@ -6571,6 +6745,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<ApiKeyTokensListResponse> viewApiKeysWithHttpInfo(String appId) throws ApiException {
@@ -6591,6 +6766,7 @@ public class DefaultApi {
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call viewApiKeysAsync(String appId, final ApiCallback<ApiKeyTokensListResponse> _callback) throws ApiException {
@@ -6613,6 +6789,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call viewTemplateCall(String templateId, String appId, final ApiCallback _callback) throws ApiException {
@@ -6700,6 +6877,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public TemplateResource viewTemplate(String templateId, String appId) throws ApiException {
@@ -6720,6 +6898,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<TemplateResource> viewTemplateWithHttpInfo(String templateId, String appId) throws ApiException {
@@ -6742,6 +6921,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Not Found </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call viewTemplateAsync(String templateId, String appId, final ApiCallback<TemplateResource> _callback) throws ApiException {
@@ -6766,6 +6946,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call viewTemplatesCall(String appId, Integer limit, Integer offset, String channel, final ApiCallback _callback) throws ApiException {
@@ -6861,6 +7042,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public TemplatesListResponse viewTemplates(String appId, Integer limit, Integer offset, String channel) throws ApiException {
@@ -6883,6 +7065,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public ApiResponse<TemplatesListResponse> viewTemplatesWithHttpInfo(String appId, Integer limit, Integer offset, String channel) throws ApiException {
@@ -6907,6 +7090,7 @@ public class DefaultApi {
         <tr><td> 200 </td><td> OK </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> Rate Limit Exceeded </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Unexpected error </td><td>  -  </td></tr>
      </table>
      */
     public okhttp3.Call viewTemplatesAsync(String appId, Integer limit, Integer offset, String channel, final ApiCallback<TemplatesListResponse> _callback) throws ApiException {

--- a/src/main/java/com/onesignal/client/model/CreateNotificationSuccessResponse.java
+++ b/src/main/java/com/onesignal/client/model/CreateNotificationSuccessResponse.java
@@ -75,11 +75,11 @@ public class CreateNotificationSuccessResponse {
   }
 
    /**
-   * Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200).
+   * Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly.
    * @return id
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).")
+  @ApiModelProperty(value = "Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.")
 
   public String getId() {
     return id;

--- a/src/main/java/com/onesignal/client/model/NotificationSlice.java
+++ b/src/main/java/com/onesignal/client/model/NotificationSlice.java
@@ -67,6 +67,14 @@ public class NotificationSlice {
   @SerializedName(SERIALIZED_NAME_LIMIT)
   private Integer limit;
 
+  public static final String SERIALIZED_NAME_TIME_OFFSET = "time_offset";
+  @SerializedName(SERIALIZED_NAME_TIME_OFFSET)
+  private String timeOffset;
+
+  public static final String SERIALIZED_NAME_NEXT_TIME_OFFSET = "next_time_offset";
+  @SerializedName(SERIALIZED_NAME_NEXT_TIME_OFFSET)
+  private String nextTimeOffset;
+
   public static final String SERIALIZED_NAME_NOTIFICATIONS = "notifications";
   @SerializedName(SERIALIZED_NAME_NOTIFICATIONS)
   private List<NotificationWithMeta> notifications = null;
@@ -143,6 +151,52 @@ public class NotificationSlice {
   }
 
 
+  public NotificationSlice timeOffset(String timeOffset) {
+    
+    this.timeOffset = timeOffset;
+    return this;
+  }
+
+   /**
+   * The time_offset cursor specified in the request, if any.
+   * @return timeOffset
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "The time_offset cursor specified in the request, if any.")
+
+  public String getTimeOffset() {
+    return timeOffset;
+  }
+
+
+  public void setTimeOffset(String timeOffset) {
+    this.timeOffset = timeOffset;
+  }
+
+
+  public NotificationSlice nextTimeOffset(String nextTimeOffset) {
+    
+    this.nextTimeOffset = nextTimeOffset;
+    return this;
+  }
+
+   /**
+   * An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.
+   * @return nextTimeOffset
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.")
+
+  public String getNextTimeOffset() {
+    return nextTimeOffset;
+  }
+
+
+  public void setNextTimeOffset(String nextTimeOffset) {
+    this.nextTimeOffset = nextTimeOffset;
+  }
+
+
   public NotificationSlice notifications(List<NotificationWithMeta> notifications) {
     
     this.notifications = notifications;
@@ -187,12 +241,14 @@ public class NotificationSlice {
     return Objects.equals(this.totalCount, notificationSlice.totalCount) &&
         Objects.equals(this.offset, notificationSlice.offset) &&
         Objects.equals(this.limit, notificationSlice.limit) &&
+        Objects.equals(this.timeOffset, notificationSlice.timeOffset) &&
+        Objects.equals(this.nextTimeOffset, notificationSlice.nextTimeOffset) &&
         Objects.equals(this.notifications, notificationSlice.notifications);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(totalCount, offset, limit, notifications);
+    return Objects.hash(totalCount, offset, limit, timeOffset, nextTimeOffset, notifications);
   }
 
   @Override
@@ -202,6 +258,8 @@ public class NotificationSlice {
     sb.append("    totalCount: ").append(toIndentedString(totalCount)).append("\n");
     sb.append("    offset: ").append(toIndentedString(offset)).append("\n");
     sb.append("    limit: ").append(toIndentedString(limit)).append("\n");
+    sb.append("    timeOffset: ").append(toIndentedString(timeOffset)).append("\n");
+    sb.append("    nextTimeOffset: ").append(toIndentedString(nextTimeOffset)).append("\n");
     sb.append("    notifications: ").append(toIndentedString(notifications)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -228,6 +286,8 @@ public class NotificationSlice {
     openapiFields.add("total_count");
     openapiFields.add("offset");
     openapiFields.add("limit");
+    openapiFields.add("time_offset");
+    openapiFields.add("next_time_offset");
     openapiFields.add("notifications");
 
     // a set of required properties/fields (JSON key names)


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety
- feat: [SDK-4790] declare default error responses for all operations

### 🐛 Bug Fixes
- fix: [SDK-4438] type-narrow Java getErrorMessages envelope handling
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...09ec934](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...09ec934ab3eec4c769d5dc0f3cf9ad9a3f088b26)._