### PR TITLE
feat: add v5.8.1 package updates

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23,7 +23,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - description: How many notifications to return.  Max is 50.  Default is 50.
@@ -177,7 +177,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - explode: false
@@ -233,7 +233,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - explode: false
@@ -451,7 +451,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       responses:
@@ -494,7 +494,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -544,7 +544,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: "Segments are listed in ascending order of created_at date. offset\
@@ -613,7 +613,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -673,7 +673,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: The segment_id can be found in the URL of the segment when viewing
@@ -736,7 +736,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: "Required\nComma-separated list of names and the value (sum/count)\
@@ -839,7 +839,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: The name of the Live Activity defined in your app. This should
@@ -899,7 +899,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: Live Activity record ID
@@ -959,7 +959,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -1027,7 +1027,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1085,7 +1085,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1147,7 +1147,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1217,7 +1217,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1280,7 +1280,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1356,7 +1356,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1434,7 +1434,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1517,7 +1517,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1573,7 +1573,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1637,7 +1637,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1685,7 +1685,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1754,7 +1754,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -1824,7 +1824,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: The type of token to use when looking up the subscription. See
@@ -1895,7 +1895,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - description: "The id of the message found in the creation notification POST\
@@ -1999,7 +1999,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -2076,7 +2076,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       responses:
@@ -2125,7 +2125,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       - description: Maximum number of templates. Default and max is 50.
@@ -2247,7 +2247,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       responses:
@@ -2296,7 +2296,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       responses:
@@ -2345,7 +2345,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       requestBody:
@@ -2396,7 +2396,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: form
       requestBody:
@@ -2440,7 +2440,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       responses:
@@ -2478,7 +2478,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -2523,7 +2523,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -2567,7 +2567,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -2621,7 +2621,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       - explode: false
@@ -2668,7 +2668,7 @@ paths:
         name: app_id
         required: true
         schema:
-          example: 00000000-0000-0000-0000-000000000000
+          example: YOUR_APP_ID
           type: string
         style: simple
       requestBody:
@@ -3355,20 +3355,23 @@ components:
       type: object
     Purchase:
       example:
-        amount: amount
-        iso: iso
+        amount: "0.99"
+        iso: USD
         count: 2
-        sku: sku
+        sku: com.example.coins100
       properties:
         sku:
           description: The unique identifier of the purchased item.
+          example: com.example.coins100
           type: string
         amount:
           description: "The amount, in USD, spent purchasing the item."
+          example: "0.99"
           type: string
         iso:
           description: The 3-letter ISO 4217 currency code. Required for correct storage
             and conversion of amount.
+          example: USD
           type: string
         count:
           type: integer
@@ -3417,18 +3420,22 @@ components:
         field:
           description: Required. Name of the field to use as the first operand in
             the filter expression.
+          example: tag
           type: string
         key:
           description: "If `field` is `tag`, this field is *required* to specify `key`\
             \ inside the tags."
+          example: level
           type: string
         value:
           description: Constant value to use as the second operand in the filter expression.
             This value is *required* when the relation operator is a binary operator.
+          example: "10"
           type: string
         hours_ago:
           description: "If `field` is session-related, this is *required* to specify\
             \ the number of hours before or after the user's session."
+          example: "24"
           type: string
         radius:
           description: "If `field` is `location`, this will specify the radius in\
@@ -3471,17 +3478,19 @@ components:
       - $ref: '#/components/schemas/Operator'
     Segment:
       example:
-        name: name
-        id: id
+        name: Inactive 30 days
+        id: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
         filters:
         - null
         - null
       properties:
         id:
           description: "UUID of the segment.  If left empty, it will be assigned automaticaly."
+          example: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
           type: string
         name:
           description: Name of the segment.  You'll see this name on the Web UI.
+          example: Inactive 30 days
           type: string
         filters:
           description: "Filter or operators the segment will have.  For a list of\
@@ -3707,42 +3716,51 @@ components:
     IdentityObject:
       additionalProperties:
         type: string
+      example:
+        external_id: YOUR_USER_EXTERNAL_ID
       type: object
     PropertiesObject:
       example:
-        country: country
+        country: US
         purchases:
-        - amount: amount
-          iso: iso
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
-        - amount: amount
-          iso: iso
+          sku: com.example.coins100
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
-        ip: ip
-        timezone_id: timezone_id
-        language: language
+          sku: com.example.coins100
+        ip: 203.0.113.10
+        timezone_id: America/Los_Angeles
+        language: en
         first_active: 1
         last_active: 5
         lat: 0.8008281904610115
         long: 6.027456183070403
         tags:
-          key: ""
+          level: "10"
+          vip: "true"
         amount_spent: 5.637376656633329
       properties:
         tags:
           additionalProperties: true
+          example:
+            level: "10"
+            vip: "true"
           type: object
         language:
+          example: en
           type: string
         timezone_id:
+          example: America/Los_Angeles
           type: string
         lat:
           type: number
         long:
           type: number
         country:
+          example: US
           type: string
         first_active:
           type: integer
@@ -3755,19 +3773,20 @@ components:
             $ref: '#/components/schemas/Purchase'
           type: array
         ip:
+          example: 203.0.113.10
           type: string
       type: object
     PropertiesDeltas:
       example:
         purchases:
-        - amount: amount
-          iso: iso
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
-        - amount: amount
-          iso: iso
+          sku: com.example.coins100
+        - amount: "0.99"
+          iso: USD
           count: 2
-          sku: sku
+          sku: com.example.coins100
         session_count: 6
         session_time: 0
       properties:
@@ -3782,25 +3801,26 @@ components:
       type: object
     Subscription:
       example:
-        notification_types: 7
-        device_model: device_model
-        app_version: app_version
-        web_p256: web_p256
-        net_type: 4
+        notification_types: 1
+        device_model: "iPhone14,2"
+        app_version: 1.0.0
+        web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+        net_type: 9
         type: iOSPush
-        device_os: device_os
+        device_os: "17.1"
         enabled: true
-        session_time: 9
-        test_type: 2
-        token: token
-        carrier: carrier
-        session_count: 3
-        web_auth: web_auth
+        session_time: 60
+        test_type: 7
+        token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+        carrier: Verizon
+        session_count: 1
+        web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
         rooted: true
-        id: id
-        sdk: sdk
+        id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+        sdk: 5.2.0
       properties:
         id:
+          example: e4e87830-b954-4363-b7bc-1f01dbaee5c8
           type: string
         type:
           enum:
@@ -3819,95 +3839,108 @@ components:
           - SMS
           type: string
         token:
+          example: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
           type: string
         enabled:
+          example: true
           type: boolean
         notification_types:
+          example: 1
           type: integer
         session_time:
+          example: 60
           type: integer
         session_count:
+          example: 1
           type: integer
         sdk:
+          example: 5.2.0
           type: string
         device_model:
+          example: "iPhone14,2"
           type: string
         device_os:
+          example: "17.1"
           type: string
         rooted:
           type: boolean
         test_type:
           type: integer
         app_version:
+          example: 1.0.0
           type: string
         net_type:
           type: integer
         carrier:
+          example: Verizon
           type: string
         web_auth:
+          example: 5DUmpGmLuTxWCLj5lJpwLQ
           type: string
         web_p256:
+          example: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
           type: string
       type: object
     User:
       example:
         subscriptions:
-        - notification_types: 7
-          device_model: device_model
-          app_version: app_version
-          web_p256: web_p256
-          net_type: 4
+        - notification_types: 1
+          device_model: "iPhone14,2"
+          app_version: 1.0.0
+          web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+          net_type: 9
           type: iOSPush
-          device_os: device_os
+          device_os: "17.1"
           enabled: true
-          session_time: 9
-          test_type: 2
-          token: token
-          carrier: carrier
-          session_count: 3
-          web_auth: web_auth
+          session_time: 60
+          test_type: 7
+          token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+          carrier: Verizon
+          session_count: 1
+          web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
           rooted: true
-          id: id
-          sdk: sdk
-        - notification_types: 7
-          device_model: device_model
-          app_version: app_version
-          web_p256: web_p256
-          net_type: 4
+          id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+          sdk: 5.2.0
+        - notification_types: 1
+          device_model: "iPhone14,2"
+          app_version: 1.0.0
+          web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+          net_type: 9
           type: iOSPush
-          device_os: device_os
+          device_os: "17.1"
           enabled: true
-          session_time: 9
-          test_type: 2
-          token: token
-          carrier: carrier
-          session_count: 3
-          web_auth: web_auth
+          session_time: 60
+          test_type: 7
+          token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+          carrier: Verizon
+          session_count: 1
+          web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
           rooted: true
-          id: id
-          sdk: sdk
+          id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+          sdk: 5.2.0
         identity:
-          key: identity
+          external_id: YOUR_USER_EXTERNAL_ID
         properties:
-          country: country
+          country: US
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          ip: ip
-          timezone_id: timezone_id
-          language: language
+            sku: com.example.coins100
+          ip: 203.0.113.10
+          timezone_id: America/Los_Angeles
+          language: en
           first_active: 1
           last_active: 5
           lat: 0.8008281904610115
           long: 6.027456183070403
           tags:
-            key: ""
+            level: "10"
+            vip: "true"
           amount_spent: 5.637376656633329
       properties:
         properties:
@@ -3915,6 +3948,8 @@ components:
         identity:
           additionalProperties:
             type: string
+          example:
+            external_id: YOUR_USER_EXTERNAL_ID
           type: object
         subscriptions:
           items:
@@ -3926,36 +3961,37 @@ components:
         refresh_device_metadata: false
         deltas:
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
+            sku: com.example.coins100
           session_count: 6
           session_time: 0
         properties:
-          country: country
+          country: US
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          ip: ip
-          timezone_id: timezone_id
-          language: language
+            sku: com.example.coins100
+          ip: 203.0.113.10
+          timezone_id: America/Los_Angeles
+          language: en
           first_active: 1
           last_active: 5
           lat: 0.8008281904610115
           long: 6.027456183070403
           tags:
-            key: ""
+            level: "10"
+            vip: "true"
           amount_spent: 5.637376656633329
       properties:
         properties:
@@ -4754,25 +4790,26 @@ components:
     PropertiesBody:
       example:
         properties:
-          country: country
+          country: US
           purchases:
-          - amount: amount
-            iso: iso
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          - amount: amount
-            iso: iso
+            sku: com.example.coins100
+          - amount: "0.99"
+            iso: USD
             count: 2
-            sku: sku
-          ip: ip
-          timezone_id: timezone_id
-          language: language
+            sku: com.example.coins100
+          ip: 203.0.113.10
+          timezone_id: America/Los_Angeles
+          language: en
           first_active: 1
           last_active: 5
           lat: 0.8008281904610115
           long: 6.027456183070403
           tags:
-            key: ""
+            level: "10"
+            vip: "true"
           amount_spent: 5.637376656633329
       properties:
         properties:
@@ -4781,23 +4818,23 @@ components:
     SubscriptionBody:
       example:
         subscription:
-          notification_types: 7
-          device_model: device_model
-          app_version: app_version
-          web_p256: web_p256
-          net_type: 4
+          notification_types: 1
+          device_model: "iPhone14,2"
+          app_version: 1.0.0
+          web_p256: BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A
+          net_type: 9
           type: iOSPush
-          device_os: device_os
+          device_os: "17.1"
           enabled: true
-          session_time: 9
-          test_type: 2
-          token: token
-          carrier: carrier
-          session_count: 3
-          web_auth: web_auth
+          session_time: 60
+          test_type: 7
+          token: d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7
+          carrier: Verizon
+          session_count: 1
+          web_auth: 5DUmpGmLuTxWCLj5lJpwLQ
           rooted: true
-          id: id
-          sdk: sdk
+          id: e4e87830-b954-4363-b7bc-1f01dbaee5c8
+          sdk: 5.2.0
       properties:
         subscription:
           $ref: '#/components/schemas/Subscription'
@@ -4817,11 +4854,13 @@ components:
     UserIdentityBody:
       example:
         identity:
-          key: identity
+          external_id: YOUR_USER_EXTERNAL_ID
       properties:
         identity:
           additionalProperties:
             type: string
+          example:
+            external_id: YOUR_USER_EXTERNAL_ID
           type: object
       type: object
     ExportEventsSuccessResponse:
@@ -5785,6 +5824,7 @@ components:
             \ the `include_unsubscribed` value from the template will be inherited.\
             \ If you are using a third-party ESP, this field requires the ESP's list\
             \ of unsubscribed emails to be cleared."
+          nullable: true
           type: boolean
           writeOnly: true
         email_bcc:

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -114,7 +114,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | 
     try {
       GenericSuccessBoolResponse result = apiInstance.cancelNotification(appId, notificationId);
@@ -191,7 +191,7 @@ public class Example {
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
     String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     CopyTemplateRequest copyTemplateRequest = new CopyTemplateRequest(); // CopyTemplateRequest | 
     try {
       TemplateResource result = apiInstance.copyTemplateToApp(templateId, appId, copyTemplateRequest);
@@ -266,7 +266,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     UserIdentityBody userIdentityBody = new UserIdentityBody(); // UserIdentityBody | 
@@ -347,7 +347,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     UserIdentityBody userIdentityBody = new UserIdentityBody(); // UserIdentityBody | 
     try {
@@ -426,7 +426,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(); // CreateApiKeyRequest | 
     try {
       CreateApiKeyResponse result = apiInstance.createApiKey(appId, createApiKeyRequest);
@@ -573,7 +573,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    String appId = "YOUR_APP_ID"; // String | Your OneSignal App ID in UUID v4 format.
     CustomEventsRequest customEventsRequest = new CustomEventsRequest(); // CustomEventsRequest | 
     try {
       Object result = apiInstance.createCustomEvents(appId, customEventsRequest);
@@ -659,6 +659,9 @@ public class Example {
     LanguageStringMap contents = new LanguageStringMap();
     contents.setEn("Hello from OneSignal!");
     notification.setContents(contents);
+    LanguageStringMap headings = new LanguageStringMap();
+    headings.setEn("Push Notification");
+    notification.setHeadings(headings);
     Map<String, List<String>> aliases = new HashMap<>();
     aliases.put("external_id", Arrays.asList("YOUR_USER_EXTERNAL_ID"));
     notification.setIncludeAliases(aliases);
@@ -728,6 +731,9 @@ public class Example {
     LanguageStringMap contents = new LanguageStringMap();
     contents.setEn("Hello from OneSignal!");
     notification.setContents(contents);
+    LanguageStringMap headings = new LanguageStringMap();
+    headings.setEn("Push Notification");
+    notification.setHeadings(headings);
     Map<String, List<String>> aliases = new HashMap<>();
     aliases.put("external_id", Arrays.asList("YOUR_USER_EXTERNAL_ID"));
     notification.setIncludeAliases(aliases);
@@ -807,7 +813,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "YOUR_APP_ID"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     Segment segment = new Segment(); // Segment | 
     try {
       CreateSegmentSuccessResponse result = apiInstance.createSegment(appId, segment);
@@ -883,7 +889,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     SubscriptionBody subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
@@ -1038,7 +1044,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     User user = new User(); // User | 
     try {
       User result = apiInstance.createUser(appId, user);
@@ -1130,7 +1136,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     String aliasLabelToDelete = "external_id"; // String | 
@@ -1211,7 +1217,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff"; // String | 
     try {
       Object result = apiInstance.deleteApiKey(appId, tokenId);
@@ -1285,7 +1291,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "YOUR_APP_ID"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     String segmentId = "d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e"; // String | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
     try {
       GenericSuccessBoolResponse result = apiInstance.deleteSegment(appId, segmentId);
@@ -1361,7 +1367,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     try {
       apiInstance.deleteSubscription(appId, subscriptionId);
@@ -1438,7 +1444,7 @@ public class Example {
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
     String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     try {
       GenericSuccessBoolResponse result = apiInstance.deleteTemplate(templateId, appId);
       System.out.println(result);
@@ -1512,7 +1518,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     try {
@@ -1590,7 +1596,7 @@ public class Example {
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
     String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | The ID of the notification to export events from.
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The ID of the app that the notification belongs to.
+    String appId = "YOUR_APP_ID"; // String | The ID of the app that the notification belongs to.
     try {
       ExportEventsSuccessResponse result = apiInstance.exportEvents(notificationId, appId);
       System.out.println(result);
@@ -1665,7 +1671,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The app ID that you want to export devices from
+    String appId = "YOUR_APP_ID"; // String | The app ID that you want to export devices from
     ExportSubscriptionsRequestBody exportSubscriptionsRequestBody = new ExportSubscriptionsRequestBody(); // ExportSubscriptionsRequestBody | 
     try {
       ExportSubscriptionsSuccessResponse result = apiInstance.exportSubscriptions(appId, exportSubscriptionsRequestBody);
@@ -1740,7 +1746,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     try {
@@ -1818,7 +1824,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     try {
       UserIdentityBody result = apiInstance.getAliasesBySubscription(appId, subscriptionId);
@@ -1893,7 +1899,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | An app id
+    String appId = "YOUR_APP_ID"; // String | An app id
     try {
       App result = apiInstance.getApp(appId);
       System.out.println(result);
@@ -2036,7 +2042,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | 
     try {
       NotificationWithMeta result = apiInstance.getNotification(appId, notificationId);
@@ -2188,7 +2194,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The app ID that you want to view notifications from
+    String appId = "YOUR_APP_ID"; // String | The app ID that you want to view notifications from
     Integer limit = 10; // Integer | How many notifications to return.  Max is 50.  Default is 50.
     Integer offset = 0; // Integer | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
     Integer kind = 0; // Integer | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only 
@@ -2269,7 +2275,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "YOUR_APP_ID"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     String outcomeNames = "os__session_duration.count,os__click.count"; // String | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
     String outcomeNames2 = "os__session_duration.count"; // String | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name. 
     String outcomeTimeRange = "1d"; // String | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted. 
@@ -2352,7 +2358,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "YOUR_APP_ID"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     Integer offset = 0; // Integer | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments.
     Integer limit = 10; // Integer | The amount of Segments in the response. Maximum 300.
     try {
@@ -2429,7 +2435,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     try {
@@ -2507,7 +2513,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff"; // String | 
     try {
       CreateApiKeyResponse result = apiInstance.rotateApiKey(appId, tokenId);
@@ -2581,7 +2587,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    String appId = "YOUR_APP_ID"; // String | Your OneSignal App ID in UUID v4 format.
     String activityType = "order_status"; // String | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
     StartLiveActivityRequest startLiveActivityRequest = new StartLiveActivityRequest(); // StartLiveActivityRequest | 
     try {
@@ -2658,7 +2664,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     TransferSubscriptionRequestBody transferSubscriptionRequestBody = new TransferSubscriptionRequestBody(); // TransferSubscriptionRequestBody | 
     try {
@@ -2737,7 +2743,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "YOUR_APP_ID"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     String notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88"; // String | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
     String token = "YOUR_TOKEN_ID"; // String | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
     try {
@@ -2814,7 +2820,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff"; // String | 
     UpdateApiKeyRequest updateApiKeyRequest = new UpdateApiKeyRequest(); // UpdateApiKeyRequest | 
     try {
@@ -2890,7 +2896,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | An app id
+    String appId = "YOUR_APP_ID"; // String | An app id
     App app = new App(); // App | 
     try {
       App result = apiInstance.updateApp(appId, app);
@@ -2965,7 +2971,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
+    String appId = "YOUR_APP_ID"; // String | The OneSignal App ID for your app.  Available in Keys & IDs.
     String activityId = "12345"; // String | Live Activity record ID
     UpdateLiveActivityRequest updateLiveActivityRequest = new UpdateLiveActivityRequest(); // UpdateLiveActivityRequest | 
     try {
@@ -3042,7 +3048,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51"; // String | 
     SubscriptionBody subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
     try {
@@ -3120,7 +3126,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    String appId = "YOUR_APP_ID"; // String | Your OneSignal App ID in UUID v4 format.
     String tokenType = "Email"; // String | The type of token to use when looking up the subscription. See Subscription Types.
     String token = "user@example.com"; // String | The value of the token to lookup by (e.g., email address, phone number).
     SubscriptionBody subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
@@ -3200,7 +3206,7 @@ public class Example {
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
     String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(); // UpdateTemplateRequest | 
     try {
       TemplateResource result = apiInstance.updateTemplate(templateId, appId, updateTemplateRequest);
@@ -3275,7 +3281,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     String aliasLabel = "external_id"; // String | 
     String aliasId = "YOUR_USER_EXTERNAL_ID"; // String | 
     UpdateUserRequest updateUserRequest = new UpdateUserRequest(); // UpdateUserRequest | 
@@ -3355,7 +3361,7 @@ public class Example {
     organization_api_key.setBearerToken("YOUR_ORGANIZATION_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     try {
       ApiKeyTokensListResponse result = apiInstance.viewApiKeys(appId);
       System.out.println(result);
@@ -3428,7 +3434,7 @@ public class Example {
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
     String templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c"; // String | 
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | 
+    String appId = "YOUR_APP_ID"; // String | 
     try {
       TemplateResource result = apiInstance.viewTemplate(templateId, appId);
       System.out.println(result);
@@ -3502,7 +3508,7 @@ public class Example {
     rest_api_key.setBearerToken("YOUR_REST_API_KEY");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    String appId = "00000000-0000-0000-0000-000000000000"; // String | Your OneSignal App ID in UUID v4 format.
+    String appId = "YOUR_APP_ID"; // String | Your OneSignal App ID in UUID v4 format.
     Integer limit = 10; // Integer | Maximum number of templates. Default and max is 50.
     Integer offset = 0; // Integer | Pagination offset.
     String channel = "push"; // String | Filter by delivery channel.

--- a/src/main/java/com/onesignal/client/model/Filter.java
+++ b/src/main/java/com/onesignal/client/model/Filter.java
@@ -158,7 +158,7 @@ public class Filter {
    * @return field
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "Required. Name of the field to use as the first operand in the filter expression.")
+  @ApiModelProperty(example = "tag", value = "Required. Name of the field to use as the first operand in the filter expression.")
 
   public String getField() {
     return field;
@@ -181,7 +181,7 @@ public class Filter {
    * @return key
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "If `field` is `tag`, this field is *required* to specify `key` inside the tags.")
+  @ApiModelProperty(example = "level", value = "If `field` is `tag`, this field is *required* to specify `key` inside the tags.")
 
   public String getKey() {
     return key;
@@ -204,7 +204,7 @@ public class Filter {
    * @return value
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "Constant value to use as the second operand in the filter expression. This value is *required* when the relation operator is a binary operator.")
+  @ApiModelProperty(example = "10", value = "Constant value to use as the second operand in the filter expression. This value is *required* when the relation operator is a binary operator.")
 
   public String getValue() {
     return value;
@@ -227,7 +227,7 @@ public class Filter {
    * @return hoursAgo
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "If `field` is session-related, this is *required* to specify the number of hours before or after the user's session.")
+  @ApiModelProperty(example = "24", value = "If `field` is session-related, this is *required* to specify the number of hours before or after the user's session.")
 
   public String getHoursAgo() {
     return hoursAgo;

--- a/src/main/java/com/onesignal/client/model/PropertiesObject.java
+++ b/src/main/java/com/onesignal/client/model/PropertiesObject.java
@@ -124,7 +124,7 @@ public class PropertiesObject {
    * @return tags
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "{\"level\":\"10\",\"vip\":\"true\"}", value = "")
 
   public Map<String, Object> getTags() {
     return tags;
@@ -147,7 +147,7 @@ public class PropertiesObject {
    * @return language
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "en", value = "")
 
   public String getLanguage() {
     return language;
@@ -170,7 +170,7 @@ public class PropertiesObject {
    * @return timezoneId
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "America/Los_Angeles", value = "")
 
   public String getTimezoneId() {
     return timezoneId;
@@ -239,7 +239,7 @@ public class PropertiesObject {
    * @return country
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "US", value = "")
 
   public String getCountry() {
     return country;
@@ -362,7 +362,7 @@ public class PropertiesObject {
    * @return ip
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "203.0.113.10", value = "")
 
   public String getIp() {
     return ip;

--- a/src/main/java/com/onesignal/client/model/Purchase.java
+++ b/src/main/java/com/onesignal/client/model/Purchase.java
@@ -82,7 +82,7 @@ public class Purchase {
    * @return sku
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "The unique identifier of the purchased item.")
+  @ApiModelProperty(example = "com.example.coins100", required = true, value = "The unique identifier of the purchased item.")
 
   public String getSku() {
     return sku;
@@ -105,7 +105,7 @@ public class Purchase {
    * @return amount
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "The amount, in USD, spent purchasing the item.")
+  @ApiModelProperty(example = "0.99", required = true, value = "The amount, in USD, spent purchasing the item.")
 
   public String getAmount() {
     return amount;
@@ -128,7 +128,7 @@ public class Purchase {
    * @return iso
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "The 3-letter ISO 4217 currency code. Required for correct storage and conversion of amount.")
+  @ApiModelProperty(example = "USD", required = true, value = "The 3-letter ISO 4217 currency code. Required for correct storage and conversion of amount.")
 
   public String getIso() {
     return iso;

--- a/src/main/java/com/onesignal/client/model/Segment.java
+++ b/src/main/java/com/onesignal/client/model/Segment.java
@@ -81,7 +81,7 @@ public class Segment {
    * @return id
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "UUID of the segment.  If left empty, it will be assigned automaticaly.")
+  @ApiModelProperty(example = "d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7", value = "UUID of the segment.  If left empty, it will be assigned automaticaly.")
 
   public String getId() {
     return id;
@@ -104,7 +104,7 @@ public class Segment {
    * @return name
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "Name of the segment.  You'll see this name on the Web UI.")
+  @ApiModelProperty(example = "Inactive 30 days", required = true, value = "Name of the segment.  You'll see this name on the Web UI.")
 
   public String getName() {
     return name;

--- a/src/main/java/com/onesignal/client/model/Subscription.java
+++ b/src/main/java/com/onesignal/client/model/Subscription.java
@@ -203,7 +203,7 @@ public class Subscription {
    * @return id
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "e4e87830-b954-4363-b7bc-1f01dbaee5c8", value = "")
 
   public String getId() {
     return id;
@@ -249,7 +249,7 @@ public class Subscription {
    * @return token
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "d5d4d1a8-1c9e-42fb-b3f2-56d3a5a9a8b7", value = "")
 
   public String getToken() {
     return token;
@@ -272,7 +272,7 @@ public class Subscription {
    * @return enabled
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "true", value = "")
 
   public Boolean getEnabled() {
     return enabled;
@@ -295,7 +295,7 @@ public class Subscription {
    * @return notificationTypes
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "1", value = "")
 
   public Integer getNotificationTypes() {
     return notificationTypes;
@@ -318,7 +318,7 @@ public class Subscription {
    * @return sessionTime
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "60", value = "")
 
   public Integer getSessionTime() {
     return sessionTime;
@@ -341,7 +341,7 @@ public class Subscription {
    * @return sessionCount
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "1", value = "")
 
   public Integer getSessionCount() {
     return sessionCount;
@@ -364,7 +364,7 @@ public class Subscription {
    * @return sdk
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "5.2.0", value = "")
 
   public String getSdk() {
     return sdk;
@@ -387,7 +387,7 @@ public class Subscription {
    * @return deviceModel
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "iPhone14,2", value = "")
 
   public String getDeviceModel() {
     return deviceModel;
@@ -410,7 +410,7 @@ public class Subscription {
    * @return deviceOs
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "17.1", value = "")
 
   public String getDeviceOs() {
     return deviceOs;
@@ -479,7 +479,7 @@ public class Subscription {
    * @return appVersion
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "1.0.0", value = "")
 
   public String getAppVersion() {
     return appVersion;
@@ -525,7 +525,7 @@ public class Subscription {
    * @return carrier
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "Verizon", value = "")
 
   public String getCarrier() {
     return carrier;
@@ -548,7 +548,7 @@ public class Subscription {
    * @return webAuth
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "5DUmpGmLuTxWCLj5lJpwLQ", value = "")
 
   public String getWebAuth() {
     return webAuth;
@@ -571,7 +571,7 @@ public class Subscription {
    * @return webP256
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "BM5-r8DauQXOb2E-3PgLPjSvjT0Ao9v5oJhw8bZ0cW7Vh6BbmPYcqbbCEJ1P2sK0hZ7HxSh9zGyU5pQk1jJmZ8A", value = "")
 
   public String getWebP256() {
     return webP256;

--- a/src/main/java/com/onesignal/client/model/User.java
+++ b/src/main/java/com/onesignal/client/model/User.java
@@ -115,7 +115,7 @@ public class User {
    * @return identity
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "{\"external_id\":\"YOUR_USER_EXTERNAL_ID\"}", value = "")
 
   public Map<String, String> getIdentity() {
     return identity;

--- a/src/main/java/com/onesignal/client/model/UserIdentityBody.java
+++ b/src/main/java/com/onesignal/client/model/UserIdentityBody.java
@@ -81,7 +81,7 @@ public class UserIdentityBody {
    * @return identity
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(example = "{\"external_id\":\"YOUR_USER_EXTERNAL_ID\"}", value = "")
 
   public Map<String, String> getIdentity() {
     return identity;


### PR DESCRIPTION
## Release v5.8.1

### 🐛 Bug Fixes
- fix: omit include_unsubscribed from requests when unset

### 📚 Docs
- docs: [SDK-4800] add AGENTS.md agent entry point to each SDK
- docs: [SDK-4800] fix AGENTS.md Rust import, retry base-delay, absolute README links
- docs: [SDK-4839] standardize auth placeholders in api doc examples
- docs: [SDK-4839] add realistic example values to user/segment/subscription schemas
- docs: [SDK-4842] standardize app-id placeholder, add headings to all push examples, note dateutil dependency
- docs: [SDK-4842] add example values for Purchase, Subscription id/carrier/web keys, and PropertiesObject.ip
- docs: [SDK-4842] add example values for Filter fields and IdentityObject entries
- docs: [SDK-4842] render valid Ruby in model doc examples and drop asymmetric identity sample

---
_Generated from [OneSignal/api-client-libraries@bcdc6a2...c6344eb](https://github.com/OneSignal/api-client-libraries/compare/bcdc6a2557a59d9bfce7fd2eb67877147b0a48e6...c6344eba29ae12a71c2b02c5cf6081ab38651ea4)._