### PR TITLE
chore: pin conventional-changelog-conventionalcommits to v9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
               -p @semantic-release/exec \
               -p @semantic-release/git \
               -p @semantic-release/github \
-              -p conventional-changelog-conventionalcommits \
+              -p conventional-changelog-conventionalcommits@9 \
               semantic-release 2>&1) && exit_code=0 || exit_code=$?
           echo "$output"
           if echo "$output" | grep -q "Published release"; then


### PR DESCRIPTION
Pin `conventional-changelog-conventionalcommits` to v9 in `.github/workflows/release.yml`.